### PR TITLE
feat: add capability validation and session filtering

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": { "name": "Kobiton Inc." },
   "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": { "name": "Kobiton Inc." },
   "license": "MIT",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*           @kobiton/vn-repo-owner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1 - 2026-04-01
+
+- Added a user confirmation prompt when selecting an app version for testing.
+- Enabled Claude to open active test sessions for live screen previews.
+
+
 ## 1.0.0 - 2026-03-31
 
 - Initial release with 12 MCP tools and 1 skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## 1.0.2 - 2026-04-02
+
+- Improved the accuracy of fetching Appium capabilities supported by Kobiton
+- Implemented a reliable method for correlating active sessions with their corresponding device IDs
+
+
 ## 1.0.1 - 2026-04-01
 
-- Added a user confirmation prompt when selecting an app version for testing.
-- Enabled Claude to open active test sessions for live screen previews.
+- Added a user confirmation prompt when selecting an app version for testing
+- Enabled Claude to open active test sessions for live screen previews
 
 
 ## 1.0.0 - 2026-03-31

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "devDependencies": {
     "js-yaml": "^4.1.0",
     "vitest": "^3.0.0"
+  },
+  "dependencies": {
+    "ejs": "^5.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ejs:
+        specifier: ^5.0.1
+        version: 5.0.1
     devDependencies:
       js-yaml:
         specifier: ^4.1.0
@@ -370,6 +374,11 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  ejs@5.0.1:
+    resolution: {integrity: sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==}
+    engines: {node: '>=0.12.18'}
+    hasBin: true
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -789,6 +798,8 @@ snapshots:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  ejs@5.0.1: {}
 
   es-module-lexer@1.7.0: {}
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -7,11 +7,19 @@ description: Run local Appium test scripts against Kobiton devices. Guides you t
 
 ### 1. Identify the app
 
-Ask the user which app to test, or detect from the project context (look for .apk, .ipa, .zip files or build output directories).
+**IMPORTANT: Always ask the user this question, even if they already provided an app file path. Do NOT skip ahead or start uploading automatically.**
 
-Upload via `uploadAppToStore` (permanent, visible in app repository).
+Ask the user:
 
-This is a three-step process: call the tool to get a pre-signed URL, upload the file via PUT, then confirm the upload.
+> "Would you like to:"
+> 1. Upload a new app build
+> 2. Use an existing app from Kobiton Store or a provided URL
+
+Wait for their response before proceeding. Do not call any upload or app-related tools until the user responds.
+
+**If uploading a new app:** Look for .apk, .ipa, .zip files in the project context, or ask the user for the file path. Upload via `uploadAppToStore` (permanent, visible in app repository). This is a three-step process: call the tool to get a pre-signed URL, upload the file via PUT, then confirm the upload.
+
+**If reusing an existing app:** Check `appium:app` field of capabilities in the test script. Call `listApps` with that app version as keywork to check uploaded or not. Let the user pick the version to use (e.g., `kobiton-store:v72107`) if needed
 
 ### 2. Select a device
 
@@ -65,9 +73,57 @@ Session Name: Verify Appium session
 Command:      node /path/to/test.js 9B211FFAZ0017F
 ```
 
-Wait for user confirmation, then execute the command via the Bash tool.
+Wait for user confirmation, then execute the command via the Bash tool **in the background** (use `run_in_background: true`). This allows the user to review the running session in the browser while the script executes.
 
-### 5. Collect results
+### 5. Open running session in browser
+
+Ask the user:
+
+> "Would you like me to open the running session in the browser?"
+
+Wait for their response. If they decline, skip to Step 6.
+
+If they agree, wait **2 seconds** after the script was launched in Step 4 (to allow the session to initialize on Kobiton), then open the session in the user's browser.
+
+**Determine the portal URL:** Read `.mcp.json` to get the MCP server URL, then map it to the portal base URL:
+
+| MCP Server | Portal Base URL |
+|------------|----------------|
+| `api.kobiton.com` | `https://portal.kobiton.com` |
+| `api-test-green.kobiton.com` | `https://portal-test.kobiton.com` |
+
+**Build the launch URL:**
+
+```
+<portal-base-url>/devices/launch?id=<deviceId>
+```
+
+Where `<deviceId>` is the ID of the selected device from Step 2 (returned by `listDevices`, `getDeviceStatus`, or `reserveDevice`).
+
+**Browser preference:** Check auto memory for a saved browser preference. If none exists, ask the user which browser to use:
+
+> "Which browser should I open the session in?"
+> 1. Google Chrome
+> 2. Safari
+> 3. Firefox
+> 4. Default browser
+
+Save their choice to auto memory so they are not asked again in future sessions.
+
+**Open the link:**
+
+| Choice | Command |
+|--------|---------|
+| Google Chrome | `open -na "Google Chrome" --args --new-window <url>` |
+| Safari | `open -a "Safari" <url>` |
+| Firefox | `open -a "Firefox" <url>` |
+| Default browser | `open <url>` |
+
+On Linux, use `xdg-open <url>` (browser selection is not supported — always opens the default).
+
+### 6. Collect results
+
+Wait for the background script to complete, then collect results.
 
 Call `getSession` with the session ID to get detailed results.
 
@@ -86,7 +142,7 @@ Call `getSessionArtifacts` with the session ID to retrieve:
 - `reserveDevice` fails (device already taken): call `listDevices` again to find another available device.
 - Script execution fails: check error output for missing dependencies (e.g. `wd`, `appium`), incorrect UDID, or network issues. Suggest fixes.
 
-### 6. Summarize
+### 7. Summarize
 
 Present a summary to the user:
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -59,6 +59,27 @@ Identify how the UDID is passed into the script (CLI argument, environment varia
 
 **Appium runtime:** Check if the script contains `'kobiton:runtime': 'appium'` or equivalent. If it does NOT, do not inject it — the default Kobiton runtime will be used. Only if the user explicitly asks to use the Appium runtime should you suggest adding `'kobiton:runtime': 'appium'` to the script's capabilities.
 
+**Validate capabilities:** After parsing the script, run the render script to generate the correct capabilities for the selected device and app:
+
+```
+node skills/run-automation-suite/scripts/render-capabilities.js \
+  --platformName <platform> \
+  --udid <udid> \
+  --deviceName "<deviceName>" \
+  --platformVersion <version> \
+  --automationName <automationName> \
+  --app <app> \
+  --testingType app
+```
+
+For web testing, replace `--app <app>` with `--browserName <browser> --testingType web`.
+
+Compare the JSON output against the parsed script capabilities:
+
+- **Must-match** (`platformName`, `platformVersion`, `appium:udid`, `appium:deviceName`, `appium:app`/`browserName`, `appium:automationName`): If different, show what will change and edit the script automatically. These must match the selected device/app.
+- **Suggested defaults** (`kobiton:sessionName`, `kobiton:sessionDescription`, `kobiton:deviceOrientation`, `kobiton:captureScreenshots`, `appium:noReset`, `appium:fullReset`): If different or missing, show the diff and ask the user before changing. The user may have intentionally set different values.
+- **User-controlled**: Any capabilities in the user's script that are not in the rendered output — leave untouched. Never inject or modify `kobiton:runtime` unless the user explicitly asks.
+
 ### 4. Confirm & execute
 
 Present a summary to the user before running:
@@ -123,7 +144,7 @@ On Linux, use `xdg-open <url>` (browser selection is not supported — always op
 
 ### 6. Collect results
 
-While the background script is running, call `listSessions` with `deviceId=<deviceId>` (from Step 2) and `state='RUNNING'` to find the session that just triggered. Use the most recent session (first result) as the match.
+While the background script is running, call `listSessions` with `deviceId=<deviceId>` (from Step 2) and `state='START'` to find the session that just triggered. Use the most recent session (first result) as the match.
 
 Call `getSession` with the matched session ID to get detailed results.
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -123,9 +123,9 @@ On Linux, use `xdg-open <url>` (browser selection is not supported — always op
 
 ### 6. Collect results
 
-Wait for the background script to complete, then collect results.
+While the background script is running, call `listSessions` with `deviceId=<deviceId>` (from Step 2) and `state='RUNNING'` to find the session that just triggered. Use the most recent session (first result) as the match.
 
-Call `getSession` with the session ID to get detailed results.
+Call `getSession` with the matched session ID to get detailed results.
 
 Call `getSessionArtifacts` with the session ID to retrieve:
 

--- a/skills/run-automation-suite/references/templates/appium.ejs
+++ b/skills/run-automation-suite/references/templates/appium.ejs
@@ -1,0 +1,31 @@
+{
+  "kobiton:sessionName": "<%= sessionName %>",
+  "kobiton:sessionDescription": "<%= sessionDescription %>",
+<% if (orientation) { %>
+  "kobiton:deviceOrientation": "<%= orientation %>",
+<% } %>
+  "kobiton:captureScreenshots": <%= captureScreenshots %>,
+<% if (showCleanUpDeviceOnExit) { %>
+  "appium:noReset": <%= !cleanUpDeviceOnExit %>,
+  "appium:fullReset": <%= cleanUpDeviceOnExit %>,
+<% } %>
+<% if (automationName) { %>
+  "appium:automationName": "<%= automationName %>",
+<% } %>
+<% if (testingType === 'web') { %>
+  "browserName": "<%= browser %>",
+<% } else { %>
+  "appium:app": "<%= app %>",
+<% } %>
+<% if (useSpecificDevice) { %>
+  "appium:udid": "<%= udid %>",
+  "appium:deviceName": "<%= deviceName %>",
+<% } else { %>
+  "appium:deviceName": "<%= deviceName %>",
+<% } %>
+<% if (showDeviceGroup) { %>
+  "kobiton:deviceGroup": "<%= deviceGroup %>",
+<% } %>
+  "platformName": "<%= platformName %>",
+  "platformVersion": "<%= platformVersion %>"
+}

--- a/skills/run-automation-suite/scripts/render-capabilities.js
+++ b/skills/run-automation-suite/scripts/render-capabilities.js
@@ -1,0 +1,79 @@
+import {readFileSync} from 'fs'
+import {resolve} from 'path'
+import ejs from 'ejs'
+import {parseArgs} from 'util'
+
+const TEMPLATE_PATH = resolve(
+  import.meta.dirname, '..', 'references', 'templates', 'appium.ejs'
+)
+
+const {values: flags} = parseArgs({
+  options: {
+    platformName:    {type: 'string'},
+    udid:            {type: 'string'},
+    deviceName:      {type: 'string'},
+    platformVersion: {type: 'string'},
+    automationName:  {type: 'string'},
+    app:             {type: 'string'},
+    browserName:     {type: 'string'},
+    testingType:     {type: 'string', default: 'app'}
+  },
+  strict: false
+})
+
+// Validate required flags
+const errors = []
+if (!flags.platformName) errors.push('--platformName is required')
+if (!flags.udid) errors.push('--udid is required')
+if (!flags.deviceName) errors.push('--deviceName is required')
+if (!flags.platformVersion) errors.push('--platformVersion is required')
+if (flags.testingType === 'app' && !flags.app) {
+  errors.push('--app is required when --testingType is app')
+}
+if (flags.testingType === 'web' && !flags.browserName) {
+  errors.push('--browserName is required when --testingType is web')
+}
+if (errors.length) {
+  process.stderr.write(errors.join('\n') + '\n')
+  process.exit(1)
+}
+
+// Build template variables: CLI flags + hardcoded defaults
+const templateVars = {
+  // From CLI
+  platformName: flags.platformName,
+  udid: flags.udid,
+  deviceName: flags.deviceName,
+  platformVersion: flags.platformVersion,
+  automationName: flags.automationName || '',
+  app: flags.app || '',
+  browser: flags.browserName || '',
+  testingType: flags.testingType,
+
+  // Hardcoded defaults
+  sessionName: 'Automation test session',
+  sessionDescription: '',
+  orientation: 'portrait',
+  captureScreenshots: true,
+  showCleanUpDeviceOnExit: true,
+  cleanUpDeviceOnExit: false,
+  useSpecificDevice: true,
+  deviceGroup: 'ORGANIZATION',
+  showDeviceGroup: false
+}
+
+// Render template and output JSON
+try {
+  const template = readFileSync(TEMPLATE_PATH, 'utf8')
+  const rendered = ejs.render(template, templateVars)
+
+  // Clean trailing commas before closing brace (EJS conditionals can leave them)
+  const cleaned = rendered.replace(/,(\s*})/g, '$1')
+
+  // Validate it's valid JSON
+  const caps = JSON.parse(cleaned)
+  process.stdout.write(JSON.stringify(caps, null, 2) + '\n')
+} catch (err) {
+  process.stderr.write(`Template render error: ${err.message}\n`)
+  process.exit(1)
+}

--- a/skills/run-automation-suite/scripts/render-capabilities.test.js
+++ b/skills/run-automation-suite/scripts/render-capabilities.test.js
@@ -1,0 +1,152 @@
+import {describe, it, expect} from 'vitest'
+import {execFileSync} from 'child_process'
+import {resolve} from 'path'
+
+const SCRIPT = resolve(import.meta.dirname, 'render-capabilities.js')
+
+function run(args) {
+  const result = execFileSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    timeout: 5000
+  })
+  return JSON.parse(result)
+}
+
+function runExpectError(args) {
+  try {
+    execFileSync('node', [SCRIPT, ...args], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    throw new Error('Expected script to fail')
+  } catch (err) {
+    return {exitCode: err.status, stderr: err.stderr}
+  }
+}
+
+describe('render-capabilities', () => {
+  it('renders app testing capabilities', () => {
+    const result = run([
+      '--platformName', 'Android',
+      '--udid', '21161FDF60051K',
+      '--deviceName', 'Pixel 6',
+      '--platformVersion', '15',
+      '--automationName', 'UiAutomator2',
+      '--app', 'kobiton-store:v72116',
+      '--testingType', 'app'
+    ])
+
+    expect(result['platformName']).toBe('Android')
+    expect(result['platformVersion']).toBe('15')
+    expect(result['appium:udid']).toBe('21161FDF60051K')
+    expect(result['appium:deviceName']).toBe('Pixel 6')
+    expect(result['appium:automationName']).toBe('UiAutomator2')
+    expect(result['appium:app']).toBe('kobiton-store:v72116')
+    expect(result['kobiton:sessionName']).toBe('Automation test session')
+    expect(result['kobiton:captureScreenshots']).toBe(true)
+    expect(result['kobiton:deviceOrientation']).toBe('portrait')
+    expect(result['appium:noReset']).toBe(true)
+    expect(result['appium:fullReset']).toBe(false)
+    expect(result['browserName']).toBeUndefined()
+  })
+
+  it('renders web testing capabilities', () => {
+    const result = run([
+      '--platformName', 'iOS',
+      '--udid', '00008101-0004257E3C30001E',
+      '--deviceName', 'iPhone 12',
+      '--platformVersion', '16.2',
+      '--automationName', 'XCUITest',
+      '--browserName', 'safari',
+      '--testingType', 'web'
+    ])
+
+    expect(result['platformName']).toBe('iOS')
+    expect(result['platformVersion']).toBe('16.2')
+    expect(result['browserName']).toBe('safari')
+    expect(result['appium:app']).toBeUndefined()
+    expect(result['appium:automationName']).toBe('XCUITest')
+    expect(result['appium:udid']).toBe('00008101-0004257E3C30001E')
+    expect(result['appium:deviceName']).toBe('iPhone 12')
+  })
+
+  it('fails when required --platformName is missing', () => {
+    const {exitCode, stderr} = runExpectError([
+      '--udid', 'ABC123',
+      '--deviceName', 'Pixel 6',
+      '--platformVersion', '15',
+      '--testingType', 'app',
+      '--app', 'kobiton-store:v1'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('platformName')
+  })
+
+  it('fails when required --udid is missing', () => {
+    const {exitCode, stderr} = runExpectError([
+      '--platformName', 'Android',
+      '--deviceName', 'Pixel 6',
+      '--platformVersion', '15',
+      '--testingType', 'app',
+      '--app', 'kobiton-store:v1'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('udid')
+  })
+
+  it('fails when required --deviceName is missing', () => {
+    const {exitCode, stderr} = runExpectError([
+      '--platformName', 'Android',
+      '--udid', 'ABC123',
+      '--platformVersion', '15',
+      '--testingType', 'app',
+      '--app', 'kobiton-store:v1'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('deviceName')
+  })
+
+  it('fails when required --platformVersion is missing', () => {
+    const {exitCode, stderr} = runExpectError([
+      '--platformName', 'Android',
+      '--udid', 'ABC123',
+      '--deviceName', 'Pixel 6',
+      '--testingType', 'app',
+      '--app', 'kobiton-store:v1'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('platformVersion')
+  })
+
+  it('fails when --testingType is app but --app is missing', () => {
+    const {exitCode, stderr} = runExpectError([
+      '--platformName', 'Android',
+      '--udid', 'ABC123',
+      '--deviceName', 'Pixel 6',
+      '--platformVersion', '15',
+      '--testingType', 'app'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('app')
+  })
+
+  it('fails when --testingType is web but --browserName is missing', () => {
+    const {exitCode, stderr} = runExpectError([
+      '--platformName', 'iOS',
+      '--udid', 'ABC123',
+      '--deviceName', 'iPhone 12',
+      '--platformVersion', '16.2',
+      '--testingType', 'web'
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('browserName')
+  })
+
+})

--- a/tools/sessions.yaml
+++ b/tools/sessions.yaml
@@ -20,11 +20,13 @@ tools:
         state:
           type: string
           enum:
-            - RUNNING
+            - START
+            - COMPLETE
             - PASSED
             - FAILED
-            - ERRORED
-            - COMPLETE
+            - TIMEOUT
+            - ERROR
+            - TERMINATED
           description: Filter by session state
         deviceId:
           type: integer

--- a/tools/sessions.yaml
+++ b/tools/sessions.yaml
@@ -17,7 +17,7 @@ tools:
             A brief summary of what the user is trying to accomplish with this
             tool call, refined from their original prompt. Used for audit
             logging.
-        status:
+        state:
           type: string
           enum:
             - RUNNING
@@ -25,10 +25,19 @@ tools:
             - FAILED
             - ERRORED
             - COMPLETE
-          description: Filter by session status
+          description: Filter by session state
+        deviceId:
+          type: integer
+          description: >-
+            Filter by Kobiton device ID (numeric ID returned by listDevices)
         deviceName:
           type: string
           description: Filter by device name (partial match)
+        keyword:
+          type: string
+          description: >-
+            Search across session name, device name, model, UDID, or platform
+            version
         platform:
           type: string
           enum:


### PR DESCRIPTION
## Summary
- **Session filtering**: Add `deviceId`, `keyword`, and `state` params to `listSessions` tool for reliable session lookup by device
- **Capability validation**: Add render script + EJS template to generate correct Kobiton capabilities, enabling the skill to detect and fix mismatches in user scripts
- **Session state fix**: Use actual database values (`START`, `COMPLETE`, `PASSED`, `FAILED`, `TIMEOUT`, `ERROR`, `TERMINATED`) instead of incorrect display names

## Changes
- `tools/sessions.yaml` — new `deviceId`, `keyword`, `state` params with correct enum values
- `skills/run-automation-suite/SKILL.md` — capability validation in Step 3, session lookup via `deviceId` in Step 6
- `skills/run-automation-suite/scripts/render-capabilities.js` — CLI tool rendering EJS template to JSON capabilities
- `skills/run-automation-suite/scripts/render-capabilities.test.js` — 8 tests covering app/web rendering and error cases
- `skills/run-automation-suite/references/templates/appium.ejs` — JSON-producing capability template

## Test plan
- [x] 8 render-capabilities tests pass (app, web, 6 error cases)
- [x] 22 total project tests pass
- [x] Project validation passes (`pnpm run validate`)
- [x] Manual E2E: `listSessions(deviceId=9702248, state='START')` returns running session
- [x] Manual E2E: render script outputs correct JSON for Android app and iOS web scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)