### PR TITLE
feat: add GitHub Copilot CLI support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,11 +3,16 @@
   "owner": {
     "name": "Kobiton Inc."
   },
+  "metadata": {
+    "description": "Kobiton mobile testing platform plugins for AI coding assistants",
+    "version": "1.0.0"
+  },
   "plugins": [{
     "name": "automate",
-    "source": "./",
+    "version": "1.0.2",
     "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
     "category": "testing",
-    "tags": ["mobile", "testing", "appium", "automation", "devices", "kobiton"]
+    "tags": ["mobile", "testing", "appium", "automation", "devices", "kobiton"],
+    "source": "./"
   }]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   "license": "MIT",
   "repository": "https://github.com/kobiton/automate",
   "homepage": "https://kobiton.com",
-  "keywords": ["mobile", "testing", "appium", "automation", "devices", "kobiton"]
+  "keywords": ["mobile", "testing", "appium", "automation", "devices", "kobiton"],
+  "mcpServers": "./.mcp.json"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,42 @@
 .claude/
-.vscode/
 node_modules/
 dist/
 resources/
-**features/
+**/features/
+**/plans/
+
+# OS
 .DS_Store
+._*
+Thumbs.db
+Desktop.ini
+
+# Editor
+.idea
+.vscode
+.cursor
+.history
+
+# Vim/Emacs
+*.swp
+*.swo
+*~
+
+# Logs
 *.log
-*.local.json
 pnpm-debug.log*
-.vscode/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Config local
+.env
+.env.local
+.env.*.local
+.envrc
+*.local.json
+
+# Test coverage
+coverage/
+*.lcov
+.eslintcache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Kobiton Automate
+
+This plugin connects to the Kobiton mobile testing platform via MCP. It provides tools for managing devices, apps, and test sessions.
+
+## Available Tools
+
+Use these MCP tools for device, session, and app management:
+
+- **Devices:** `listDevices`, `getDeviceStatus`, `reserveDevice`, `terminateReservation`
+- **Sessions:** `listSessions`, `getSession`, `getSessionArtifacts`, `terminateSession`
+- **Apps:** `listApps`, `getApp`, `uploadAppToStore`, `confirmAppUpload`
+
+## Running Automation Tests
+
+Use the **run-automation-suite** skill for guided test execution. It walks through app upload, device selection, Appium script parsing, and local execution with result collection.
+
+## Authentication
+
+Authentication is handled by the MCP server. Connect to the `kobiton` MCP server to authenticate via OAuth or API key.

--- a/README.md
+++ b/README.md
@@ -4,35 +4,60 @@
 [![Cloud](https://img.shields.io/badge/Cloud-☁️-blue)](https://kobiton.com)
 [![Twitter Follow](https://img.shields.io/twitter/follow/KobitonMobile?style=social)](https://x.com/KobitonMobile)
 
-Claude Code plugin for the [Kobiton](https://kobiton.com) mobile testing platform. Manage devices, upload apps, run automation sessions, and view test results directly from your AI coding assistant.
+Plugin for the [Kobiton](https://kobiton.com) mobile testing platform. Works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) and [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli). Manage devices, upload apps, run automation sessions, and view test results directly from your AI coding assistant.
 
 ## Before You Begin
 
 Make sure you have:
 
 - **A Kobiton account** — sign up at [kobiton.com](https://kobiton.com) if you don't have one
-- **Claude Code installed and working** — verify by running `claude` in your terminal ([install guide](https://docs.anthropic.com/en/docs/claude-code/overview))
-- **A workspace folder opened** — Claude Code must be launched from a project directory (e.g. `cd my-project && claude`)
+- **Claude Code or GitHub Copilot CLI** — install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) or [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
+- **A project directory** — your AI assistant must launch from a workspace, not from your home folder
 
 ## Installation
 
-### From Claude Code Marketplace
+### Claude Code
+
+Open your project and start a Claude Code session:
 
 ```bash
-# add kobiton marketplace
-/plugin marketplace add kobiton/automate
+cd my-project
+claude
+```
 
-# then install the automate plugin
+Inside the session, add the Kobiton marketplace and install the plugin:
+
+```
+/plugin marketplace add kobiton/automate
 /plugin install automate@kobiton
 ```
 
-### Login
+### GitHub Copilot CLI
 
-1. In Claude Code, type `/mcp` to open the MCP server list
-2. Select the **kobiton** server — a browser window will open for Kobiton login
-3. Sign in with your Kobiton credentials. Tokens are managed automatically.
+Open your project and start a Copilot CLI session:
 
-The `.mcp.json` points to the Kobiton MCP server. Authentication is handled via OAuth 2.1 — when you connect to the server through `/mcp`, Claude Code opens a browser for login.
+```bash
+cd my-project
+copilot
+```
+
+Inside the session, add the Kobiton marketplace and install the plugin:
+
+```
+/plugin marketplace add kobiton/automate
+/plugin install automate@kobiton
+```
+
+## Login
+
+The first time your AI assistant calls a Kobiton tool, a browser window opens for OAuth login. Sign in with your Kobiton credentials — tokens are then managed automatically by the assistant.
+
+You can also trigger or inspect authentication explicitly:
+
+- **Claude Code**: type `/mcp` and select **kobiton** to start the OAuth flow
+- **GitHub Copilot CLI**: type `/mcp` (or `/mcp show`) to inspect the MCP server status
+
+Behind the scenes, `.mcp.json` points to the Kobiton MCP server and authentication uses OAuth 2.1:
 
 ```json
 {
@@ -50,7 +75,7 @@ The `.mcp.json` points to the Kobiton MCP server. Authentication is handled via 
 
 The `X-AI-Tool-Name` header tells Kobiton's MCP server that the request originates from Claude Code so usage can be attributed correctly in adoption analytics. It is not used for authentication or routing — only for telemetry.
 
-After installation and authentication, verify the plugin loaded by asking Claude: *"List my Kobiton devices"*. If tools aren't recognized, see [Troubleshooting](#troubleshooting).
+After login, verify the plugin loaded by asking your assistant: *"List my Kobiton devices"*. If tools aren't recognized, see [Troubleshooting](#troubleshooting).
 
 ### API Key Authentication (Alternative)
 
@@ -60,12 +85,12 @@ For CI/CD pipelines or headless environments that cannot open a browser, use API
 2. Generate an API key at **Kobiton Portal > Settings > API Keys**
 3. Set the environment variable:
 
-```bash
-# Add to ~/.zshrc, ~/.bashrc, or ~/.bash_profile
-export KOBITON_AUTH="Basic $(echo -n 'username:apikey' | base64)"
-```
+   ```bash
+   # Add to ~/.zshrc, ~/.bashrc, or ~/.bash_profile
+   export KOBITON_AUTH="Basic $(echo -n 'username:apikey' | base64)"
+   ```
 
-1. Reload your shell and restart Claude Code.
+4. Reload your shell and restart Claude Code.
 
 > **Note:** OAuth and API key auth cannot coexist in a single `.mcp.json`. The default OAuth config uses a `headers` block containing only `X-AI-Tool-Name`. The API key config adds `Authorization: ${KOBITON_AUTH}` to the same `headers` block. To switch, replace `.mcp.json` with the appropriate format.
 
@@ -173,6 +198,27 @@ To make sure Claude picks up the changes with no stale cache:
 ### Common Issues
 
 <details>
+<summary><strong>MCP server doesn't appear in <code>/mcp</code> after install</strong></summary>
+
+Both Claude Code and Copilot CLI cache plugin state when the session starts. After installing or updating the plugin, the `kobiton` MCP server may not show up in the server list immediately. Force a reload:
+
+**Claude Code** — reload plugins in the current session:
+
+```
+/reload-plugins
+```
+
+**GitHub Copilot CLI** — exit and relaunch the session:
+
+```bash
+exit
+copilot
+```
+
+Then check the server list (`/mcp` in Claude Code, `/mcp show` in Copilot CLI). `kobiton` should now appear.
+</details>
+
+<details>
 <summary><strong>Plugin features not working or behaving unexpectedly</strong></summary>
 
 Some older versions of Claude Code don't support the plugin features this plugin relies on. Make sure you're on the latest version:
@@ -248,6 +294,55 @@ The device may be offline, reserved by another user, or no longer in your device
 Large app files or slow connections can cause uploads to time out. Retry the upload — pre-signed URLs expire after 30 minutes, so a new URL will be generated automatically.
 </details>
 
+### Copilot CLI
+
+<details>
+<summary><strong>MCP tools not available after plugin install</strong></summary>
+
+Verify the plugin is installed and the MCP server is configured:
+
+```bash
+# Check installed plugins
+copilot plugin list
+
+# Check MCP server status
+/mcp show
+```
+
+If the `kobiton` MCP server doesn't appear, add it manually by running `/mcp add` and entering the following when prompted:
+
+- **Server name:** `kobiton`
+- **Type:** `http`
+- **URL:** `https://api.kobiton.com/mcp`
+
+Alternatively, edit `~/.copilot/mcp-config.json` directly:
+
+```json
+{
+  "mcpServers": {
+    "kobiton": {
+      "type": "http",
+      "url": "https://api.kobiton.com/mcp"
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary><strong>Tool calls are blocked</strong></summary>
+
+Copilot CLI requires explicit tool permissions. Allow Kobiton tools:
+
+```bash
+# Allow all Kobiton MCP tools
+copilot --allow-tool='kobiton'
+
+# Or allow specific tools
+copilot --allow-tool='kobiton(listDevices)' --allow-tool='kobiton(getSession)'
+```
+</details>
+
 ### Still Stuck?
 
 For additional help, open an issue at [github.com/kobiton/automate/issues](https://github.com/kobiton/automate/issues/new?template=bug_report.md) or ask in [#general-discussion](https://discord.com/channels/1486036652685267055/1488189710248710327) on Discord. Feel free to share [feature requests](https://github.com/kobiton/automate/issues/new?template=feature_request.md). We welcome product feedback and will consider it as we continue to improve the platform.
@@ -258,14 +353,14 @@ This plugin connects to the Kobiton cloud API (`api.kobiton.com`) over HTTPS (TL
 
 **Authentication:**
 
-- **OAuth 2.1 (default):** Claude Code opens a browser for Kobiton login. Short-lived access tokens are stored securely in the system keychain by Claude Code. No credentials are stored in the project.
+- **OAuth 2.1 (default):** Your AI assistant opens a browser for Kobiton login. Short-lived access tokens are stored securely in the system keychain. No credentials are stored in the project.
 - **API Key (alternative):** The `KOBITON_AUTH` environment variable is sent via the `Authorization` header on each request. The value is stored only in your shell profile, never committed to the repo.
 
 **Data handling:**
 
-- The plugin does not store any data locally beyond what Claude Code retains in its conversation context.
-- Tool responses (device lists, session details, test results) pass through Claude Code's context window and are subject to [Anthropic's Privacy Policy](https://www.anthropic.com/privacy).
-- App binaries uploaded via `uploadAppToStore` are sent directly to Kobiton's pre-signed S3 URLs, not through Claude Code.
+- The plugin does not store any data locally beyond what your AI assistant retains in its conversation context.
+- Tool responses (device lists, session details, test results) pass through your assistant's context window and are subject to [Anthropic's Privacy Policy](https://www.anthropic.com/privacy) or [GitHub Copilot's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement), depending on which assistant you use.
+- App binaries uploaded via `uploadAppToStore` are sent directly to Kobiton's pre-signed S3 URLs, not through your AI assistant.
 
 For details on how Kobiton handles your data, see the [Kobiton Privacy Policy](https://kobiton.com/privacy-policy) and [Trust Center](https://kobiton.com/trust-center/).
 

--- a/scripts/build-tool-definitions.js
+++ b/scripts/build-tool-definitions.js
@@ -1,18 +1,42 @@
-import {readFileSync, writeFileSync, mkdirSync} from 'fs'
-import {join, resolve} from 'path'
+import {readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync} from 'node:fs'
+import {join, resolve} from 'node:path'
 import {load, dump} from 'js-yaml'
 
-const ROOT = resolve(import.meta.dirname, '..')
-const toolFiles = ['devices.yaml', 'sessions.yaml', 'apps.yaml', 'user.yaml']
+export function buildToolDefinitions(rootDir) {
+  const toolsDir = join(rootDir, 'tools')
+  if (!existsSync(toolsDir)) {
+    throw new Error('tools/ directory does not exist')
+  }
 
-const combined = {
-  files: toolFiles.map((file) => {
-    const content = readFileSync(join(ROOT, 'tools', file), 'utf8')
-    return load(content)
-  })
+  const toolFiles = readdirSync(toolsDir)
+    .filter((f) => f.endsWith('.yaml'))
+    .sort()
+
+  if (toolFiles.length === 0) {
+    throw new Error('tools/ contains no YAML files')
+  }
+
+  const combined = {
+    files: toolFiles.map((file) => {
+      const content = readFileSync(join(toolsDir, file), 'utf8')
+      return load(content)
+    })
+  }
+
+  return {combined, toolFiles}
 }
 
-mkdirSync(join(ROOT, 'dist'), {recursive: true})
-const outputPath = join(ROOT, 'dist', 'tool-definitions.yaml')
-writeFileSync(outputPath, dump(combined))
-console.log(`Built ${outputPath}`)
+// CLI runner
+const isMainModule = import.meta.url === `file://${process.argv[1]}`
+if (isMainModule) {
+  const ROOT = resolve(import.meta.dirname, '..')
+  const {combined} = buildToolDefinitions(ROOT)
+
+  const distDir = join(ROOT, 'dist')
+  mkdirSync(distDir, {recursive: true})
+
+  const outputPath = join(distDir, 'tool-definitions.yaml')
+  writeFileSync(outputPath, dump(combined))
+
+  console.log(`Built ${outputPath}`)
+}

--- a/scripts/build-tool-definitions.test.js
+++ b/scripts/build-tool-definitions.test.js
@@ -1,0 +1,96 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
+import {mkdtempSync, mkdirSync, writeFileSync, rmSync} from 'node:fs'
+import {join} from 'node:path'
+import {tmpdir} from 'node:os'
+import {load, dump} from 'js-yaml'
+import {buildToolDefinitions} from './build-tool-definitions.js'
+
+function writeToolFile(dir, filename, domain, toolName) {
+  writeFileSync(join(dir, 'tools', filename), [
+    `domain: ${domain}`,
+    'tools:',
+    `  - name: ${toolName}`,
+    `    description: ${toolName} description`,
+    '    inputSchema:',
+    '      type: object',
+  ].join('\n'))
+}
+
+function setupValidProject(dir) {
+  mkdirSync(join(dir, 'tools'))
+  writeToolFile(dir, 'devices.yaml', 'DEVICE', 'listDevices')
+  writeToolFile(dir, 'sessions.yaml', 'SESSION', 'listSessions')
+}
+
+describe('buildToolDefinitions', () => {
+  let tmpDir
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'automate-build-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, {recursive: true, force: true})
+  })
+
+  it('throws when tools/ directory is missing', () => {
+    expect(() => buildToolDefinitions(tmpDir)).toThrow('tools/ directory does not exist')
+  })
+
+  it('throws when tools/ contains no YAML files', () => {
+    mkdirSync(join(tmpDir, 'tools'))
+    expect(() => buildToolDefinitions(tmpDir)).toThrow('tools/ contains no YAML files')
+  })
+
+  it('combines YAML files into {files: [...]} structure', () => {
+    setupValidProject(tmpDir)
+    const {combined} = buildToolDefinitions(tmpDir)
+    expect(combined).toHaveProperty('files')
+    expect(Array.isArray(combined.files)).toBe(true)
+    expect(combined.files).toHaveLength(2)
+  })
+
+  it('preserves domain and tools array per file', () => {
+    setupValidProject(tmpDir)
+    const {combined} = buildToolDefinitions(tmpDir)
+    const domains = combined.files.map((f) => f.domain)
+    expect(domains).toContain('DEVICE')
+    expect(domains).toContain('SESSION')
+    for (const file of combined.files) {
+      expect(Array.isArray(file.tools)).toBe(true)
+      expect(file.tools.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('auto-discovers new YAML files without code change', () => {
+    setupValidProject(tmpDir)
+    writeToolFile(tmpDir, 'extras.yaml', 'EXTRA', 'extraTool')
+    const {combined, toolFiles} = buildToolDefinitions(tmpDir)
+    expect(combined.files).toHaveLength(3)
+    expect(toolFiles).toContain('extras.yaml')
+  })
+
+  it('ignores non-YAML files in tools/', () => {
+    setupValidProject(tmpDir)
+    writeFileSync(join(tmpDir, 'tools', 'README.md'), '# Tools')
+    writeFileSync(join(tmpDir, 'tools', 'notes.txt'), 'notes')
+    const {combined, toolFiles} = buildToolDefinitions(tmpDir)
+    expect(combined.files).toHaveLength(2)
+    expect(toolFiles).not.toContain('README.md')
+    expect(toolFiles).not.toContain('notes.txt')
+  })
+
+  it('output is YAML round-trip safe', () => {
+    setupValidProject(tmpDir)
+    const {combined} = buildToolDefinitions(tmpDir)
+    const yaml = dump(combined)
+    const parsed = load(yaml)
+    expect(parsed).toEqual(combined)
+  })
+
+  it('returns toolFiles in deterministic (alphabetical) order', () => {
+    setupValidProject(tmpDir)
+    const {toolFiles} = buildToolDefinitions(tmpDir)
+    expect(toolFiles).toEqual(['devices.yaml', 'sessions.yaml'])
+  })
+})

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,13 +1,17 @@
-import {readFileSync, existsSync} from 'fs'
-import {resolve, join} from 'path'
+import {readFileSync, existsSync, readdirSync} from 'node:fs'
+import {resolve, join} from 'node:path'
 import {load} from 'js-yaml'
 
 export function validateProject(rootDir) {
   const errors = []
   const passes = []
 
-  function fail(msg) { errors.push(msg) }
-  function pass(msg) { passes.push(msg) }
+  function fail(msg) {
+    errors.push(msg)
+  }
+  function pass(msg) {
+    passes.push(msg)
+  }
 
   // Validate JSON files exist and parse
   const jsonFiles = [
@@ -25,7 +29,8 @@ export function validateProject(rootDir) {
     try {
       JSON.parse(readFileSync(filePath, 'utf8'))
       pass(`${file} is valid JSON`)
-    } catch (e) {
+    }
+    catch (e) {
       fail(`${file} is not valid JSON: ${e.message}`)
     }
   }
@@ -33,10 +38,17 @@ export function validateProject(rootDir) {
   // Validate plugin.json required fields
   for (const pluginPath of ['.claude-plugin/plugin.json']) {
     const filePath = join(rootDir, pluginPath)
-    if (!existsSync(filePath)) continue
+    if (!existsSync(filePath)) {
+      continue
+    }
+
     const plugin = JSON.parse(readFileSync(filePath, 'utf8'))
-    if (!plugin.name) fail(`${pluginPath} missing "name"`)
-    if (!plugin.description) fail(`${pluginPath} missing "description"`)
+    if (!plugin.name) {
+      fail(`${pluginPath} missing "name"`)
+    }
+    if (!plugin.description) {
+      fail(`${pluginPath} missing "description"`)
+    }
   }
 
   // Validate .mcp.json has server config (accepts OAuth, API key, or minimal format)
@@ -44,82 +56,126 @@ export function validateProject(rootDir) {
   if (existsSync(mcpPath)) {
     try {
       const mcp = JSON.parse(readFileSync(mcpPath, 'utf8'))
-      if (!mcp.mcpServers || !mcp.mcpServers.kobiton) {
+      if (!mcp.mcpServers?.kobiton) {
         fail('.mcp.json missing mcpServers.kobiton')
-      } else if (!mcp.mcpServers.kobiton.url) {
+      }
+      else if (!mcp.mcpServers.kobiton.url) {
         fail('.mcp.json missing mcpServers.kobiton.url')
-      } else {
+      }
+      else {
         const kobiton = mcp.mcpServers.kobiton
         if (kobiton.oauth != null && (typeof kobiton.oauth !== 'object' || typeof kobiton.oauth.authServerMetadataUrl !== 'string')) {
           fail('.mcp.json oauth block missing authServerMetadataUrl (string)')
         }
       }
-    } catch {
+    }
+    catch {
       // Already caught by JSON validation above
     }
   }
 
-  // Validate tool YAML files
-  const toolFiles = ['devices.yaml', 'sessions.yaml', 'apps.yaml', 'user.yaml']
-
-  for (const file of toolFiles) {
-    const filePath = join(rootDir, 'tools', file)
-    if (!existsSync(filePath)) {
-      fail(`tools/${file} does not exist`)
-      continue
+  // Validate tool YAML files (auto-discovered from tools/)
+  const toolsDir = join(rootDir, 'tools')
+  if (!existsSync(toolsDir)) {
+    fail('tools/ directory does not exist')
+  }
+  else {
+    const toolFiles = readdirSync(toolsDir).filter((f) => f.endsWith('.yaml'))
+    if (toolFiles.length === 0) {
+      fail('tools/ contains no YAML files')
     }
-    try {
-      const doc = load(readFileSync(filePath, 'utf8'))
-      if (!doc.tools || !Array.isArray(doc.tools)) {
-        fail(`tools/${file} missing "tools" array`)
-        continue
+    for (const file of toolFiles) {
+      const filePath = join(toolsDir, file)
+      try {
+        const doc = load(readFileSync(filePath, 'utf8'))
+
+        if (!doc.tools || !Array.isArray(doc.tools)) {
+          fail(`tools/${file} missing "tools" array`)
+          continue
+        }
+
+        for (const tool of doc.tools) {
+          if (!tool.name) {
+            fail(`tools/${file} has tool without "name"`)
+          }
+          if (!tool.description) {
+            fail(`tools/${file} tool "${tool.name}" missing "description"`)
+          }
+          if (!tool.inputSchema) {
+            fail(`tools/${file} tool "${tool.name}" missing "inputSchema"`)
+          }
+        }
+        pass(`tools/${file} is valid (${doc.tools.length} tools)`)
       }
-      for (const tool of doc.tools) {
-        if (!tool.name) fail(`tools/${file} has tool without "name"`)
-        if (!tool.description) fail(`tools/${file} tool "${tool.name}" missing "description"`)
-        if (!tool.inputSchema) fail(`tools/${file} tool "${tool.name}" missing "inputSchema"`)
+      catch (e) {
+        fail(`tools/${file} is not valid YAML: ${e.message}`)
       }
-      pass(`tools/${file} is valid (${doc.tools.length} tools)`)
-    } catch (e) {
-      fail(`tools/${file} is not valid YAML: ${e.message}`)
     }
   }
 
-  // Validate skills have frontmatter
-  const skillDirs = ['run-automation-suite', 'run-interactive-test']
-  for (const skill of skillDirs) {
-    const filePath = join(rootDir, 'skills', skill, 'SKILL.md')
-    if (!existsSync(filePath)) {
-      fail(`skills/${skill}/SKILL.md does not exist`)
-      continue
+  // Validate skills have frontmatter (auto-discovered from skills/)
+  const skillsDir = join(rootDir, 'skills')
+  if (!existsSync(skillsDir)) {
+    fail('skills/ directory does not exist')
+  }
+  else {
+    const skillDirs = readdirSync(skillsDir, {withFileTypes: true})
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+
+    if (skillDirs.length === 0) {
+      fail('skills/ contains no skill subdirectories')
     }
-    const content = readFileSync(filePath, 'utf8')
-    if (!content.startsWith('---')) {
-      fail(`skills/${skill}/SKILL.md missing YAML frontmatter`)
-      continue
+
+    for (const skill of skillDirs) {
+      const filePath = join(skillsDir, skill, 'SKILL.md')
+      if (!existsSync(filePath)) {
+        fail(`skills/${skill}/SKILL.md does not exist`)
+        continue
+      }
+
+      const content = readFileSync(filePath, 'utf8')
+      if (!content.startsWith('---')) {
+        fail(`skills/${skill}/SKILL.md missing YAML frontmatter`)
+        continue
+      }
+
+      const frontmatterEnd = content.indexOf('---', 3)
+      if (frontmatterEnd === -1) {
+        fail(`skills/${skill}/SKILL.md has unclosed frontmatter`)
+        continue
+      }
+
+      const frontmatter = load(content.slice(3, frontmatterEnd))
+      if (!frontmatter.name) {
+        fail(`skills/${skill}/SKILL.md frontmatter missing "name"`)
+      }
+      if (!frontmatter.description) {
+        fail(`skills/${skill}/SKILL.md frontmatter missing "description"`)
+      }
+      else {
+        pass(`skills/${skill}/SKILL.md is valid`)
+      }
     }
-    const frontmatterEnd = content.indexOf('---', 3)
-    if (frontmatterEnd === -1) {
-      fail(`skills/${skill}/SKILL.md has unclosed frontmatter`)
-      continue
-    }
-    const frontmatter = load(content.slice(3, frontmatterEnd))
-    if (!frontmatter.name) fail(`skills/${skill}/SKILL.md frontmatter missing "name"`)
-    if (!frontmatter.description) fail(`skills/${skill}/SKILL.md frontmatter missing "description"`)
-    else pass(`skills/${skill}/SKILL.md is valid`)
   }
 
   // Validate referenced paths exist
   const claudePluginPath = join(rootDir, '.claude-plugin/plugin.json')
   if (existsSync(claudePluginPath)) {
     const claudePlugin = JSON.parse(readFileSync(claudePluginPath, 'utf8'))
-    if (claudePlugin.mcpServers) {
-      const ref = resolve(join(rootDir, '.claude-plugin'), claudePlugin.mcpServers)
-      if (!existsSync(ref)) fail(`plugin.json references ${claudePlugin.mcpServers} but it does not exist`)
+
+    if (typeof claudePlugin.mcpServers === 'string') {
+      const ref = resolve(rootDir, claudePlugin.mcpServers)
+      if (!existsSync(ref)) {
+        fail(`plugin.json references ${claudePlugin.mcpServers} but it does not exist`)
+      }
     }
-    if (claudePlugin.skills) {
-      const ref = resolve(join(rootDir, '.claude-plugin'), claudePlugin.skills)
-      if (!existsSync(ref)) fail(`plugin.json references ${claudePlugin.skills} but it does not exist`)
+
+    if (typeof claudePlugin.skills === 'string') {
+      const ref = resolve(rootDir, claudePlugin.skills)
+      if (!existsSync(ref)) {
+        fail(`plugin.json references ${claudePlugin.skills} but it does not exist`)
+      }
     }
   }
 
@@ -132,9 +188,17 @@ if (isMainModule) {
   const ROOT = resolve(import.meta.dirname, '..')
   const {errors, passes} = validateProject(ROOT)
 
-  for (const msg of passes) console.log(`OK:   ${msg}`)
-  for (const msg of errors) console.error(`FAIL: ${msg}`)
+  for (const msg of passes) {
+    console.log(`OK:   ${msg}`)
+  }
+  for (const msg of errors) {
+    console.error(`FAIL: ${msg}`)
+  }
 
-  console.log(`\n${errors.length === 0 ? 'All checks passed.' : `${errors.length} error(s) found.`}`)
+  const summary = errors.length === 0
+    ? 'All checks passed.'
+    : `${errors.length} error(s) found.`
+  console.log(`\n${summary}`)
+
   process.exit(errors.length === 0 ? 0 : 1)
 }

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -13,8 +13,8 @@ function setupValidProject(dir) {
   writeFileSync(join(dir, '.claude-plugin/plugin.json'), JSON.stringify({
     name: 'automate',
     description: 'Test',
-    mcpServers: '../.mcp.json',
-    skills: '../skills/'
+    mcpServers: './.mcp.json',
+    skills: './skills/'
   }))
   writeFileSync(join(dir, '.claude-plugin/marketplace.json'), JSON.stringify({
     name: 'kobiton',
@@ -96,8 +96,8 @@ describe('validateProject', () => {
     setupValidProject(tmpDir)
     writeFileSync(join(tmpDir, '.claude-plugin/plugin.json'), JSON.stringify({
       description: 'Test',
-      mcpServers: '../.mcp.json',
-      skills: '../skills/'
+      mcpServers: './.mcp.json',
+      skills: './skills/'
     }))
     const {errors} = validateProject(tmpDir)
     expect(errors).toContainEqual(expect.stringContaining('missing "name"'))
@@ -144,8 +144,8 @@ describe('validateProject', () => {
     writeFileSync(join(tmpDir, '.claude-plugin/plugin.json'), JSON.stringify({
       name: 'test',
       description: 'Test',
-      mcpServers: '../nonexistent.json',
-      skills: '../skills/'
+      mcpServers: './nonexistent.json',
+      skills: './skills/'
     }))
     const {errors} = validateProject(tmpDir)
     expect(errors).toContainEqual(expect.stringContaining('does not exist'))

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -114,7 +114,7 @@ Session Name: Verify Appium session
 Command:      node /path/to/test.js 9B211FFAZ0017F
 ```
 
-Wait for user confirmation, then execute the command via the Bash tool **in the background** (use `run_in_background: true`).
+Wait for user confirmation, then execute the command **in the background** using your shell execution tool.
 
 **Immediately after launching the script**, wait **2 seconds** (to allow the session to initialize on Kobiton), then open the running session in the user's browser.
 


### PR DESCRIPTION
## Summary

Make the Kobiton plugin install and run correctly on both **Claude Code** and **GitHub Copilot CLI** from a single `.claude-plugin/plugin.json` manifest. End-to-end verified on both platforms.

## What changed

### Cross-platform plugin manifest

- `plugin.json` uses `mcpServers: "./.mcp.json"` (path string, plugin-root-relative). Original `"../.mcp.json"` was rejected by Claude Code's schema validator because `..` escapes the plugin root in the cache copy.
- `skills` field dropped — both runtimes auto-discover the default `skills/` directory; an explicit declaration is redundant and surfaced its own validation issues.
- `marketplace.json` adds `metadata.{description, version}` and `plugins[].version` to match Copilot CLI's marketplace schema. Claude Code accepts the same fields (documented as backward-compatible).

### Documentation

- `AGENTS.md` (read by both Claude Code and Copilot CLI) lists tools, points at the `run-automation-suite` skill, and documents auth.
- `README.md` revamped for clarity and cross-platform friendliness:
  - Installation sections show the full flow for newcomers: `cd <project>` → launch the assistant → run install slash commands.
  - Both platforms use the same in-session install pattern (`/plugin marketplace add` then `/plugin install`) for a single mental model.
  - Login section is assistant-agnostic; per-platform manual-trigger steps are listed when needed.
  - Troubleshooting now has an entry for "MCP server doesn't appear in `/mcp` after install" covering `/reload-plugins` (Claude Code) and exit + relaunch (Copilot CLI).
  - Command syntax corrected throughout (e.g., `--allow-tool='kobiton(listDevices)'` parentheses notation, marketplace-add-then-install flow for Copilot CLI, interactive `/mcp add` instead of flag-based syntax).
- `SKILL.md` uses platform-neutral wording ("shell execution tool" instead of "Bash tool").

### Build & validate scripts

- `scripts/build-tool-definitions.js` and `scripts/validate.js` now **auto-discover** `tools/*.yaml` and `skills/*/` via `readdirSync` instead of a hardcoded file list. Adding a new tool YAML or skill directory no longer requires editing these scripts.
- Both scripts export pure functions for testing; CLI runners are thin wrappers.
- Path resolution in `validate.js` switched from `.claude-plugin/`-relative to plugin-root-relative to match Claude Code's actual behavior.
- Style cleanup: `node:fs` / `node:path` prefixes, always-braces on conditionals, Stroustrup placement.
- 8 new unit tests for `build-tool-definitions` cover output shape, auto-discovery, YAML round-trip, non-YAML filtering, and fail-fast on missing directories.

### .gitignore hygiene

- Fix `**features/` and `**plans/` to `**/features/` and `**/plans/` (the original syntax was a no-op glob)
- Remove duplicate `.vscode/` entry
- Add OS metadata (`._*`, `Thumbs.db`, `Desktop.ini`)
- Add Vim/Emacs swap files (`*.swp`, `*.swo`, `*~`)
- Add npm/yarn debug logs alongside `pnpm-debug.log*`
- Add env variants (`.env.local`, `.env.*.local`, `.envrc`)
- Add test coverage artifacts (`coverage/`, `*.lcov`, `.eslintcache`)

## Verification

| Check | Result |
|-------|--------|
| `pnpm run validate` | All 7 checks pass |
| `pnpm test` | 30 tests pass across 3 files |
| Claude Code install via marketplace | `/mcp` shows `kobiton`; OAuth + tool calls work |
| Copilot CLI install via marketplace | `/mcp show` shows `kobiton`; OAuth + tool calls work |

## Test plan

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes (30 tests)
- [x] Claude Code: `/plugin marketplace add kobiton/automate` + `/plugin install automate@kobiton` → tools load and invoke
- [x] Copilot CLI: `/plugin marketplace add kobiton/automate` + `/plugin install automate@kobiton` (or shell-level equivalents) → tools load and invoke
- [x] Both platforms read `AGENTS.md` as instructions
- [x] Troubleshooting steps verified (Claude Code `/reload-plugins`, Copilot CLI exit + relaunch)