### PR TITLE
fix(skill): frontmatter completeness + trigger phrases for autonomous activation

### DIFF
--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-automation-suite
-description: Run local Appium test scripts against Kobiton devices. Guides you through app upload, device selection, script capability parsing, and local execution.
+description: Run local Appium test scripts against Kobiton devices — guides through app upload, device selection, capability parsing, and local execution. Use when the user asks to run mobile tests, validate an APK or IPA on Kobiton devices, or kick off an Appium suite from a local script directory. Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: "Read, Edit, Bash(node:*), Bash(python:*), Bash(python3:*), Bash(mvn:*), Bash(dotnet:*), Bash(java:*), Bash(open:*), Bash(xdg-open:*)"
 version: 1.0.2
 author: Kobiton Inc.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: run-automation-suite
 description: Run local Appium test scripts against Kobiton devices. Guides you through app upload, device selection, script capability parsing, and local execution.
+allowed-tools: "Read, Edit, Bash(node:*), Bash(python:*), Bash(python3:*), Bash(mvn:*), Bash(dotnet:*), Bash(java:*), Bash(open:*), Bash(xdg-open:*)"
+version: 1.0.2
+author: Kobiton Inc.
+license: MIT
+compatibility: "Designed for Claude Code; requires Node.js >= 18 and Appium 2.x. Test scripts must use Appium WebDriver protocol."
+tags: [mobile, testing, appium, automation, devices, kobiton]
 ---
 
 ## Workflow

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -1,11 +1,25 @@
 ---
 name: run-automation-suite
-description: Run local Appium test scripts against Kobiton devices — guides through app upload, device selection, capability parsing, and local execution. Use when the user asks to run mobile tests, validate an APK or IPA on Kobiton devices, or kick off an Appium suite from a local script directory. Trigger with "run kobiton tests" or "execute appium on kobiton".
-allowed-tools: "Read, Edit, Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(python:*), Bash(python3:*), Bash(pytest:*), Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Bash(dotnet:*), Bash(ruby:*), Bash(bundle:*), Bash(rspec:*), Bash(open:*), Bash(xdg-open:*)"
+description: >-
+  Run local Appium test scripts against Kobiton devices - guides through app
+  upload, device selection, capability parsing, and local execution. Use when
+  the user asks to run mobile tests, validate an APK or IPA on Kobiton
+  devices, or kick off an Appium suite from a local script directory.
+  Trigger with "run kobiton tests" or "execute appium on kobiton".
+allowed-tools: >-
+  Read, Edit,
+  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
+  Bash(python:*), Bash(python3:*), Bash(pytest:*),
+  Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
+  Bash(dotnet:*),
+  Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
+  Bash(open:*), Bash(xdg-open:*)
 version: 1.0.2
 author: Kobiton Inc.
 license: MIT
-compatibility: "Designed for Claude Code; requires Node.js >= 18 and Appium 2.x. Test scripts must use Appium WebDriver protocol."
+compatibility: >-
+  Designed for Claude Code; requires Node.js >= 18 and Appium 2.x.
+  Test scripts must use Appium WebDriver protocol.
 tags: [mobile, testing, appium, automation, devices, kobiton]
 ---
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-automation-suite
 description: Run local Appium test scripts against Kobiton devices — guides through app upload, device selection, capability parsing, and local execution. Use when the user asks to run mobile tests, validate an APK or IPA on Kobiton devices, or kick off an Appium suite from a local script directory. Trigger with "run kobiton tests" or "execute appium on kobiton".
-allowed-tools: "Read, Edit, Bash(node:*), Bash(python:*), Bash(python3:*), Bash(mvn:*), Bash(dotnet:*), Bash(java:*), Bash(open:*), Bash(xdg-open:*)"
+allowed-tools: "Read, Edit, Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(python:*), Bash(python3:*), Bash(pytest:*), Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Bash(dotnet:*), Bash(ruby:*), Bash(bundle:*), Bash(rspec:*), Bash(open:*), Bash(xdg-open:*)"
 version: 1.0.2
 author: Kobiton Inc.
 license: MIT


### PR DESCRIPTION
## Summary

Brings the `run-automation-suite` skill frontmatter from 2/8 to 8/8 fields and adds the conventional `Use when …` / `Trigger with "…"` phrases to the description. Part of the R1 audit batch from Intent Solutions (anchor: #20).

## Changes

- **Add 6 missing frontmatter fields** - `allowed-tools`, `version`, `author`, `license`, `compatibility`, `tags`. Values mirror `.claude-plugin/plugin.json` and `marketplace.json` to keep the three surfaces in lockstep.
- **Augment `description`** with `Use when …` and `Trigger with "…"` phrases so Claude can autonomously decide when to invoke the skill instead of requiring explicit hand-routing. Total length stays under 500 chars.
- **Expand `allowed-tools` scope** to cover the full Appium ecosystem: Node test runners (`npm`/`npx`/`yarn`/`pnpm`), Python `pytest`, Java `gradle`/`./gradlew`, and the Ruby Appium client (`ruby`/`bundle`/`rspec`). Bash scoping stays per-command per Anthropic best practice (no unscoped Bash).
- **Reformat long frontmatter strings as YAML folded scalars (`>-`)** for readability. Parsed values are byte-identical to the previous single-line form (verified via `js-yaml load`).

## Type of change

- [x] Plugin metadata update

## Checklist

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes (22/22)
- [x] New skills have YAML frontmatter with `name` and `description`

## Related issues

Closes #18
Closes #19

Anchor: #20 (R1 audit batch reading order)
