### PR TITLE
fix(skill): restructure body into conventional sections

### DIFF
--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -75,12 +75,15 @@ Ask the user for the path to their local Appium test script.
 
 Detect the language and runtime from the file extension:
 
-| Extension | Runtime | Command |
-|-----------|---------|---------|
-| `.js` | Node.js | `node <script> <udid>` |
-| `.py` | Python | `python <script> <udid>` |
+| Extension | Runtime | Common commands |
+|-----------|---------|-----------------|
+| `.js` / `.ts` / `.mjs` | Node.js | `node <script> <udid>`, `npm test`, `npx wdio`, `yarn test`, `pnpm test` |
+| `.py` | Python | `python <script> <udid>`, `python3 <script> <udid>`, `pytest` |
 | `.cs` / `.csproj` | .NET | `dotnet test` |
-| `.java` | Java | `mvn test` or `java -cp ...` |
+| `.java` / `.kt` | Java / Kotlin | `mvn test`, `gradle test`, `./gradlew test`, `java -cp ...` |
+| `.rb` | Ruby | `ruby <script>`, `bundle exec rspec` |
+
+**Picking the right command:** if the project has a manifest file (`package.json`, `pyproject.toml`, `pom.xml`, `build.gradle`, `Gemfile`), prefer the matching test runner (`npm test`, `pytest`, `mvn test`, `gradle test`, `bundle exec rspec`). Otherwise default to invoking the runtime directly on the script (e.g. `node <script>`, `python3 <script>`, `ruby <script>`).
 
 Read the script file and extract key capabilities from the source code:
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -253,7 +253,23 @@ On failure, the skill surfaces error output from the test runner, the session UR
 
 ## Examples
 
-_Populated in a follow-up commit (closes #15)._
+### Run a single test on the first available Android device
+
+> "Run `./tests/checkout.js` on a Pixel 7 — upload the latest APK from `./build/app.apk` first."
+
+The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `listDevices` filtered to Pixel 7, reserves the device with `reserveDevice`, parses the script's capabilities, confirms the launch summary with the user, runs `node ./tests/checkout.js <udid>` in the background, opens the live session URL in the user's browser, and returns the session ID plus artifacts when the run completes.
+
+### Reuse a Kobiton Store build and run a Python web test
+
+> "Run `./tests/safari.py` on any iPhone with iOS 17 or higher, using `kobiton-store:v72107`."
+
+The skill skips the upload step (existing store reference), filters `listDevices` to iOS 17+ devices, reserves the first available, parses Python script capabilities (browser-based), confirms with the user, runs `python3 ./tests/safari.py <udid>` in the background, opens the portal URL, and surfaces the video plus logs once the session ends.
+
+### Re-run a prior session on the same device
+
+> "Session `abc123` ended but the screenshots showed a layout regression — run the same test on the same device so I can compare side by side."
+
+The skill calls `getSession` for `abc123` to recover the device ID and app reference, calls `reserveDevice` for the same device, re-runs the original script with the recorded capabilities, opens a fresh portal session URL, and returns the new artifacts ready for diff against the prior run.
 
 ## Resources
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -35,11 +35,11 @@ Use this skill when the user asks to run mobile tests, validate an APK or IPA ac
 
 Before invoking this skill, ensure:
 
-- **Kobiton MCP connection** — the Kobiton MCP server is reachable (default `api.kobiton.com/mcp`; check `.mcp.json` for the configured endpoint).
-- **Local Appium test script** — a runnable Appium WebDriver script (`.js`, `.ts`, `.py`, `.java`, `.kt`, `.cs`, `.rb`) referencing desired capabilities for the target platform.
-- **Runtime installed locally** — Node.js + npm/npx, Python + pip, Java + mvn/gradle, .NET SDK, or Ruby + bundle — whichever your test script uses.
-- **App build (or store reference)** — either a local `.apk` / `.ipa` / `.zip` build artifact for upload, or a `kobiton-store:vXXXXX` reference for an existing upload.
-- **Kobiton account** — credentials with device-cloud access for the target platform (Android / iOS) and remaining session quota.
+- **Kobiton MCP connection** - the Kobiton MCP server is reachable (default `api.kobiton.com/mcp`; check `.mcp.json` for the configured endpoint).
+- **Local Appium test script** - a runnable Appium WebDriver script (`.js`, `.ts`, `.py`, `.java`, `.kt`, `.cs`, `.rb`) referencing desired capabilities for the target platform.
+- **Runtime installed locally** - Node.js + npm/npx, Python + pip, Java + mvn/gradle, .NET SDK, or Ruby + bundle, whichever your test script uses.
+- **App build (or store reference)** - either a local `.apk` / `.ipa` / `.zip` build artifact for upload, or a `kobiton-store:vXXXXX` reference for an existing upload.
+- **Kobiton account** - credentials with device access for the target platform (Android / iOS) and remaining session quota.
 
 ## Instructions
 
@@ -276,8 +276,8 @@ The skill calls `getSession` for `abc123` to recover the device ID and app refer
 
 ## Resources
 
-- [Kobiton desired capabilities reference](https://docs.kobiton.com/automation-testing/desired-capabilities/) — canonical list of `kobiton:*` and supported `appium:*` capabilities the skill's `render-capabilities` step compares against.
-- [Appium 2.x documentation](https://appium.io/docs/en/2.0/) — driver-specific capability docs (UiAutomator2, XCUITest) and Appium client libraries for each runtime.
-- [Kobiton platform overview](https://kobiton.com) — the device cloud this skill targets; covers account setup, billing, and quota.
-- [`kobiton/automate` plugin source](https://github.com/kobiton/automate) — issue tracker, contribution guide, and the tool YAML schemas this skill orchestrates.
-- [Sample prompt patterns](../../docs/examples.md) — natural-language prompt examples organized per MCP tool, useful for crafting requests that trigger this skill cleanly.
+- [Kobiton available capabilities reference](https://docs.kobiton.com/automation-testing/capabilities/available-capabilities) - canonical list of `kobiton:*` and supported `appium:*` capabilities the skill's `render-capabilities` step compares against.
+- [Appium 2.x documentation](https://appium.io/docs/en/2.0/) - driver-specific capability docs (UiAutomator2, XCUITest) and Appium client libraries for each runtime.
+- [Kobiton platform overview](https://kobiton.com) - the device cloud this skill targets; covers account setup, billing, and quota.
+- [`kobiton/automate` plugin source](https://github.com/kobiton/automate) - issue tracker, contribution guide, and the tool YAML schemas this skill orchestrates.
+- [Sample prompt patterns](../../docs/examples.md) - natural-language prompt examples organized per MCP tool, useful for crafting requests that trigger this skill cleanly.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-automation-suite
 description: >-
-  Run local Appium test scripts against Kobiton devices - guides through app
+  Run local Appium test scripts against Kobiton devices. Guides through app
   upload, device selection, capability parsing, and local execution. Use when
   the user asks to run mobile tests, validate an APK or IPA on Kobiton
   devices, or kick off an Appium suite from a local script directory.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -18,8 +18,8 @@ version: 1.0.2
 author: Kobiton Inc.
 license: MIT
 compatibility: >-
-  Designed for Claude Code; requires Node.js >= 18 and Appium 2.x.
-  Test scripts must use Appium WebDriver protocol.
+  Compatible with any MCP-aware AI coding assistant. Requires Node.js >= 18
+  and Appium 2.x. Test scripts must use Appium WebDriver protocol.
 tags: [mobile, testing, appium, automation, devices, kobiton]
 ---
 
@@ -98,7 +98,7 @@ Read the script file and extract key capabilities from the source code:
 
 Identify how the UDID is passed into the script (CLI argument, environment variable, or hardcoded) so it can be overridden with the selected device.
 
-**Appium runtime:** Check if the script contains `'kobiton:runtime': 'appium'` or equivalent. If it does NOT, do not inject it — the default Kobiton runtime will be used. Only if the user explicitly asks to use the Appium runtime should you suggest adding `'kobiton:runtime': 'appium'` to the script's capabilities.
+**Appium runtime:** Check if the script contains `'kobiton:runtime': 'appium'` or equivalent. If it does NOT, do not inject it - the default Kobiton runtime will be used. Only if the user explicitly asks to use the Appium runtime should you suggest adding `'kobiton:runtime': 'appium'` to the script's capabilities.
 
 **Validate capabilities:** After parsing the script, run the render script to generate the correct capabilities for the selected device and app:
 
@@ -239,17 +239,17 @@ Present a summary to the user:
 
 On successful completion, the skill returns:
 
-- **Live session URL** — `https://portal.kobiton.com/devices/launch?id=<deviceId>`, opened automatically in the user's default browser as the script starts.
-- **Session metadata** — session ID, device ID, app version, start time, and final pass/fail status (via `getSession`).
-- **Session artifacts** — video recording URL, device logs URL, screenshots, and test reports (via `getSessionArtifacts`).
-- **Execution duration** — wall-clock time from script launch to completion.
+- **Live session URL**: `https://portal.kobiton.com/devices/launch?id=<deviceId>`, opened automatically in the user's default browser as the script starts.
+- **Session metadata**: session ID, device ID, app version, start time, and final pass/fail status (via `getSession`).
+- **Session artifacts**: video recording URL, device logs URL, screenshots, and test reports (via `getSessionArtifacts`).
+- **Execution duration**: wall-clock time from script launch to completion.
 
 On failure, the skill surfaces error output from the test runner, the session URL if the session reached Kobiton (useful for portal-side debugging), and suggested next steps drawn from the categories in `## Error Handling`.
 
 ## Error Handling
 
 - `listDevices` returns empty: suggest broadening filters (remove platform/group constraints) or trying again later when devices free up.
-- Upload fails or times out: retry the upload. Pre-signed URLs expire after 30 minutes — if expired, call the upload tool again to get a fresh URL.
+- Upload fails or times out: retry the upload. Pre-signed URLs expire after 30 minutes - if expired, call the upload tool again to get a fresh URL.
 - Session stuck in a non-terminal state: poll `getSession` with a reasonable timeout. If still running, offer to call `terminateSession` and retry.
 - `reserveDevice` fails (device already taken): call `listDevices` again to find another available device.
 - Script execution fails: check error output for missing dependencies (e.g. `wd`, `appium`), incorrect UDID, or network issues. Suggest fixes.
@@ -258,26 +258,19 @@ On failure, the skill surfaces error output from the test runner, the session UR
 
 ### Run a single test on the first available Android device
 
-> "Run `./tests/checkout.js` on a Pixel 7 — upload the latest APK from `./build/app.apk` first."
+> "Run `./tests/checkout.js` on a Pixel 7 - upload the latest APK from `./build/app.apk` first."
 
 The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `listDevices` filtered to Pixel 7, reserves the device with `reserveDevice`, parses the script's capabilities, confirms the launch summary with the user, runs `node ./tests/checkout.js <udid>` in the background, opens the live session URL in the user's browser, and returns the session ID plus artifacts when the run completes.
 
-### Reuse a Kobiton Store build and run a Python web test
+### Run an attached IPA with an attached script on a specific iOS device
 
-> "Run `./tests/safari.py` on any iPhone with iOS 17 or higher, using `kobiton-store:v72107`."
+> "Test this app @TestApp.ipa by this script @automation.js on Kobiton iOS iPhone 15 Pro"
 
-The skill skips the upload step (existing store reference), filters `listDevices` to iOS 17+ devices, reserves the first available, parses Python script capabilities (browser-based), confirms with the user, runs `python3 ./tests/safari.py <udid>` in the background, opens the portal URL, and surfaces the video plus logs once the session ends.
-
-### Re-run a prior session on the same device
-
-> "Session `abc123` ended but the screenshots showed a layout regression — run the same test on the same device so I can compare side by side."
-
-The skill calls `getSession` for `abc123` to recover the device ID and app reference, calls `reserveDevice` for the same device, re-runs the original script with the recorded capabilities, opens a fresh portal session URL, and returns the new artifacts ready for diff against the prior run.
+The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user, runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser, and surfaces the session ID plus artifacts when the run completes.
 
 ## Resources
 
 - [Kobiton available capabilities reference](https://docs.kobiton.com/automation-testing/capabilities/available-capabilities) - canonical list of `kobiton:*` and supported `appium:*` capabilities the skill's `render-capabilities` step compares against.
 - [Appium 2.x documentation](https://appium.io/docs/en/2.0/) - driver-specific capability docs (UiAutomator2, XCUITest) and Appium client libraries for each runtime.
-- [Kobiton platform overview](https://kobiton.com) - the device cloud this skill targets; covers account setup, billing, and quota.
 - [`kobiton/automate` plugin source](https://github.com/kobiton/automate) - issue tracker, contribution guide, and the tool YAML schemas this skill orchestrates.
 - [Sample prompt patterns](../../docs/examples.md) - natural-language prompt examples organized per MCP tool, useful for crafting requests that trigger this skill cleanly.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -273,4 +273,8 @@ The skill calls `getSession` for `abc123` to recover the device ID and app refer
 
 ## Resources
 
-_Populated in a follow-up commit (closes #14)._
+- [Kobiton desired capabilities reference](https://docs.kobiton.com/automation-testing/desired-capabilities/) — canonical list of `kobiton:*` and supported `appium:*` capabilities the skill's `render-capabilities` step compares against.
+- [Appium 2.x documentation](https://appium.io/docs/en/2.0/) — driver-specific capability docs (UiAutomator2, XCUITest) and Appium client libraries for each runtime.
+- [Kobiton platform overview](https://kobiton.com) — the device cloud this skill targets; covers account setup, billing, and quota.
+- [`kobiton/automate` plugin source](https://github.com/kobiton/automate) — issue tracker, contribution guide, and the tool YAML schemas this skill orchestrates.
+- [Sample prompt patterns](../../docs/examples.md) — natural-language prompt examples organized per MCP tool, useful for crafting requests that trigger this skill cleanly.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -23,6 +23,14 @@ compatibility: >-
 tags: [mobile, testing, appium, automation, devices, kobiton]
 ---
 
+# Run Automation Suite
+
+## Overview
+
+Execute Appium-based mobile test automation suites on Kobiton's device cloud. Given a local Appium test script, this skill identifies the target app, selects an available device, parses and reconciles capabilities, runs the script in the background, and surfaces the resulting session URL plus artifacts (video, logs, screenshots, reports).
+
+Use this skill when the user asks to run mobile tests, validate an APK or IPA across real devices, or trigger a Kobiton-hosted automation run from a local script directory.
+
 ## Workflow
 
 ### 1. Identify the app

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -8,11 +8,7 @@ description: >-
   Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: >-
   Read, Edit,
-  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
-  Bash(python:*), Bash(python3:*), Bash(pytest:*),
-  Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
-  Bash(dotnet:*),
-  Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
+  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(python:*), Bash(python3:*), Bash(pytest:*), Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Bash(dotnet:*), Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
   Bash(open:*), Bash(xdg-open:*)
 version: 1.0.2
 author: Kobiton Inc.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -31,7 +31,17 @@ Execute Appium-based mobile test automation suites on Kobiton's device cloud. Gi
 
 Use this skill when the user asks to run mobile tests, validate an APK or IPA across real devices, or trigger a Kobiton-hosted automation run from a local script directory.
 
-## Workflow
+## Prerequisites
+
+Before invoking this skill, ensure:
+
+- **Kobiton MCP connection** — the Kobiton MCP server is reachable (default `api.kobiton.com/mcp`; check `.mcp.json` for the configured endpoint).
+- **Local Appium test script** — a runnable Appium WebDriver script (`.js`, `.ts`, `.py`, `.java`, `.kt`, `.cs`, `.rb`) referencing desired capabilities for the target platform.
+- **Runtime installed locally** — Node.js + npm/npx, Python + pip, Java + mvn/gradle, .NET SDK, or Ruby + bundle — whichever your test script uses.
+- **App build (or store reference)** — either a local `.apk` / `.ipa` / `.zip` build artifact for upload, or a `kobiton-store:vXXXXX` reference for an existing upload.
+- **Kobiton account** — credentials with device-cloud access for the target platform (Android / iOS) and remaining session quota.
+
+## Instructions
 
 ### 1. Identify the app
 
@@ -212,14 +222,6 @@ Call `getSessionArtifacts` with the session ID to retrieve:
 - Screenshots
 - Test reports
 
-### Error handling
-
-- `listDevices` returns empty: suggest broadening filters (remove platform/group constraints) or trying again later when devices free up.
-- Upload fails or times out: retry the upload. Pre-signed URLs expire after 30 minutes — if expired, call the upload tool again to get a fresh URL.
-- Session stuck in a non-terminal state: poll `getSession` with a reasonable timeout. If still running, offer to call `terminateSession` and retry.
-- `reserveDevice` fails (device already taken): call `listDevices` again to find another available device.
-- Script execution fails: check error output for missing dependencies (e.g. `wd`, `appium`), incorrect UDID, or network issues. Suggest fixes.
-
 ### 7. Summarize
 
 Present a summary to the user:
@@ -229,3 +231,30 @@ Present a summary to the user:
 - Video recording link
 - Key error messages (if failed)
 - Execution duration
+
+## Output
+
+On successful completion, the skill returns:
+
+- **Live session URL** — `https://portal.kobiton.com/devices/launch?id=<deviceId>`, opened automatically in the user's default browser as the script starts.
+- **Session metadata** — session ID, device ID, app version, start time, and final pass/fail status (via `getSession`).
+- **Session artifacts** — video recording URL, device logs URL, screenshots, and test reports (via `getSessionArtifacts`).
+- **Execution duration** — wall-clock time from script launch to completion.
+
+On failure, the skill surfaces error output from the test runner, the session URL if the session reached Kobiton (useful for portal-side debugging), and suggested next steps drawn from the categories in `## Error Handling`.
+
+## Error Handling
+
+- `listDevices` returns empty: suggest broadening filters (remove platform/group constraints) or trying again later when devices free up.
+- Upload fails or times out: retry the upload. Pre-signed URLs expire after 30 minutes — if expired, call the upload tool again to get a fresh URL.
+- Session stuck in a non-terminal state: poll `getSession` with a reasonable timeout. If still running, offer to call `terminateSession` and retry.
+- `reserveDevice` fails (device already taken): call `listDevices` again to find another available device.
+- Script execution fails: check error output for missing dependencies (e.g. `wd`, `appium`), incorrect UDID, or network issues. Suggest fixes.
+
+## Examples
+
+_Populated in a follow-up commit (closes #15)._
+
+## Resources
+
+_Populated in a follow-up commit (closes #14)._

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -8,7 +8,11 @@ description: >-
   Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: >-
   Read, Edit,
-  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(python:*), Bash(python3:*), Bash(pytest:*), Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Bash(dotnet:*), Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
+  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
+  Bash(python:*), Bash(python3:*), Bash(pytest:*),
+  Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
+  Bash(dotnet:*),
+  Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
   Bash(open:*), Bash(xdg-open:*)
 version: 1.0.2
 author: Kobiton Inc.


### PR DESCRIPTION
## Summary

Restructures the `run-automation-suite` skill body into 7 conventional named sections (Overview, Prerequisites, Instructions, Output, Error Handling, Examples, Resources) per the Anthropic Skills spec, populates Examples and Resources with concrete content, and expands the runtime-detection table to match the broadened `allowed-tools` allowlist set in #30. Part of the R1 audit batch from Intent Solutions (anchor: #20).

## Changes

- **Top-level `# Run Automation Suite` heading + `## Overview`** (closes #17) — self-introducing top-level section so cold readers can decide if the skill fits before parsing workflow steps.
- **Restructure body into 7 named sections** (closes #16):
  - `## Prerequisites` (new) — pre-flight checklist for MCP, runtime, app build, account.
  - `## Instructions` (renamed from `## Workflow`) — 6 numbered steps preserved unchanged under new heading.
  - `## Output` (new) — documents return shape on success and failure.
  - `## Error Handling` (promoted from `### Error handling` nested inside Workflow).
  - `## Examples` and `## Resources` (new sections, populated below).
- **2 worked examples** (closes #15) — prompt → expected-behavior pairs covering Android (single device, new APK upload) and iOS (`@`-attachment pattern, specific device).
- **4 curated resources** (closes #14) — Kobiton available capabilities reference, Appium 2.x docs, plugin source, in-repo prompt examples.
- **Expanded runtime-detection table** — documents the full Appium ecosystem now in `allowed-tools` (npm/npx/yarn/pnpm, pytest, gradle/`./gradlew`, ruby/bundle/rspec) plus a 'Picking the right command' note for manifest-based selection.
- **Host-neutral compatibility field** — replaces 'Designed for Claude Code' with 'Compatible with any MCP-aware AI coding assistant' so the skill doesn't bake in host coupling. Pairs with the in-flight Copilot CLI support (#10) and Gemini CLI support (#28).

## Type of change

- [x] New skill (added to `skills/`) — body restructure
- [x] Plugin metadata update — runtime table expansion + compatibility wording

## Checklist

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes (22/22)
- [x] New skills have YAML frontmatter with `name` and `description`

## Related issues

Closes #14
Closes #15
Closes #16
Closes #17

Anchor: #20 (R1 audit batch reading order)
Stacks on: #30 (frontmatter completeness)

## Notes for reviewers

- **Stacked PR** - base branch is `fix/skill-frontmatter-audit-r1`. GitHub auto-rebases to `main` when #30 merges. Until then, the diff here may show #30's frontmatter changes depending on how GitHub renders the comparison.
