### PR TITLE
refactor(skill): extract capability tables to references/

### DIFF
--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -73,28 +73,9 @@ Reserve the device with `reserveDevice` if needed.
 
 Ask the user for the path to their local Appium test script.
 
-Detect the language and runtime from the file extension:
+Detect the language and runtime from the file extension. See [references/capabilities.md](references/capabilities.md#runtime-detection) for the full extension -> runtime -> common commands lookup and the manifest-based runner selection guidance.
 
-| Extension | Runtime | Common commands |
-|-----------|---------|-----------------|
-| `.js` / `.ts` / `.mjs` | Node.js | `node <script> <udid>`, `npm test`, `npx wdio`, `yarn test`, `pnpm test` |
-| `.py` | Python | `python <script> <udid>`, `python3 <script> <udid>`, `pytest` |
-| `.cs` / `.csproj` | .NET | `dotnet test` |
-| `.java` / `.kt` | Java / Kotlin | `mvn test`, `gradle test`, `./gradlew test`, `java -cp ...` |
-| `.rb` | Ruby | `ruby <script>`, `bundle exec rspec` |
-
-**Picking the right command:** if the project has a manifest file (`package.json`, `pyproject.toml`, `pom.xml`, `build.gradle`, `Gemfile`), prefer the matching test runner (`npm test`, `pytest`, `mvn test`, `gradle test`, `bundle exec rspec`). Otherwise default to invoking the runtime directly on the script (e.g. `node <script>`, `python3 <script>`, `ruby <script>`).
-
-Read the script file and extract key capabilities from the source code:
-
-- `platformName` (Android / iOS)
-- `udid` (hardcoded or parameterized)
-- `app` (app URL or kobiton-store reference)
-- `sessionName`, `sessionDescription`
-- `automationName` (UiAutomator2, XCUITest, etc.)
-- `browserName` (if browser-based test)
-- `deviceOrientation`
-- Any `kobiton:*` vendor extensions (especially `kobiton:runtime`)
+Read the script file and extract the [key capability fields](references/capabilities.md#capability-fields) used by Appium and Kobiton (`platformName`, `udid`, `app`, automation/browser names, vendor `kobiton:*` extensions, etc.).
 
 Identify how the UDID is passed into the script (CLI argument, environment variable, or hardcoded) so it can be overridden with the selected device.
 
@@ -115,14 +96,9 @@ node skills/run-automation-suite/scripts/render-capabilities.js \
 
 For web testing, replace `--app <app>` with `--browserName <browser> --testingType web`.
 
+Compare the JSON output against the parsed script capabilities using the [reconciliation rules](references/capabilities.md#reconciliation-rules): must-match fields are autocorrected to the rendered values, suggested defaults require user confirmation before changing, and user-controlled capabilities are left untouched.
+
 The rendered output also includes `kobiton:aiToolName: "<host>"` so Kobiton can attribute sessions started by this skill to the calling AI workspace in adoption analytics. The host is auto-detected from runtime env markers (`CLAUDECODE=1` → Claude, `COPILOT_CLI=1` → Copilot, `GEMINI_CLI=1` → Gemini, `CODEX_THREAD_ID` → Codex). Override with `--aiToolName <name>` or set `KOBITON_AI_TOOL_NAME=<name>` to force a specific value. Pass `--aiToolName ""` to omit the capability entirely.
-
-Compare the JSON output against the parsed script capabilities:
-
-- **Must-match** (`platformName`, `platformVersion`, `appium:udid`, `appium:deviceName`, `appium:app`/`browserName`, `appium:automationName`): If different, show what will change and edit the script automatically. These must match the selected device/app.
-- **Auto-injected (silent, always-overwrite)** (`kobiton:aiToolName`): Always set this to the rendered value, without prompting and without showing a diff — overwrite any pre-existing value, even if the script already has a different value baked in. This is a telemetry-only attribution capability that **must** reflect the AI host currently running the skill (Claude Code, Copilot CLI, Gemini CLI, Codex CLI, …); a stale value from an earlier run mis-attributes the session. Skip the confirmation step entirely. Do not show a diff — the user did not author this field.
-- **Suggested defaults** (`kobiton:sessionName`, `kobiton:sessionDescription`, `kobiton:deviceOrientation`, `kobiton:captureScreenshots`, `appium:noReset`, `appium:fullReset`): If different or missing, show the diff and ask the user before changing. The user may have intentionally set different values.
-- **User-controlled**: Any capabilities in the user's script that are not in the rendered output — leave untouched. Never inject or modify `kobiton:runtime` unless the user explicitly asks.
 
 ### 4. Confirm & execute
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -8,11 +8,7 @@ description: >-
   Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: >-
   Read, Edit,
-  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
-  Bash(python:*), Bash(python3:*), Bash(pytest:*),
-  Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
-  Bash(dotnet:*),
-  Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
+  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(python:*), Bash(python3:*), Bash(pytest:*), Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Bash(dotnet:*), Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
   Bash(open:*), Bash(xdg-open:*)
 version: 1.0.2
 author: Kobiton Inc.

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -8,7 +8,11 @@ description: >-
   Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: >-
   Read, Edit,
-  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(python:*), Bash(python3:*), Bash(pytest:*), Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*), Bash(dotnet:*), Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
+  Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
+  Bash(python:*), Bash(python3:*), Bash(pytest:*),
+  Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
+  Bash(dotnet:*),
+  Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
   Bash(open:*), Bash(xdg-open:*)
 version: 1.0.2
 author: Kobiton Inc.

--- a/skills/run-automation-suite/references/capabilities.md
+++ b/skills/run-automation-suite/references/capabilities.md
@@ -1,0 +1,45 @@
+# Capability Reference
+
+Reference material for the `run-automation-suite` skill. The skill orchestrates Appium test execution on Kobiton's device cloud; this file holds the lookup tables and reconciliation rules the skill consults when parsing a test script and reconciling its capabilities against the rendered defaults for the selected device.
+
+## Runtime detection
+
+Detect the language and runtime for a test script from its file extension:
+
+| Extension | Runtime | Common commands |
+|-----------|---------|-----------------|
+| `.js` / `.ts` / `.mjs` | Node.js | `node <script> <udid>`, `npm test`, `npx wdio`, `yarn test`, `pnpm test` |
+| `.py` | Python | `python <script> <udid>`, `python3 <script> <udid>`, `pytest` |
+| `.cs` / `.csproj` | .NET | `dotnet test` |
+| `.java` / `.kt` | Java / Kotlin | `mvn test`, `gradle test`, `./gradlew test`, `java -cp ...` |
+| `.rb` | Ruby | `ruby <script>`, `bundle exec rspec` |
+
+**Picking the right command:** if the project has a manifest file (`package.json`, `pyproject.toml`, `pom.xml`, `build.gradle`, `Gemfile`), prefer the matching test runner (`npm test`, `pytest`, `mvn test`, `gradle test`, `bundle exec rspec`). Otherwise default to invoking the runtime directly on the script (e.g. `node <script>`, `python3 <script>`, `ruby <script>`).
+
+## Capability fields
+
+Key Appium / Kobiton capability fields to extract from a parsed test script:
+
+- `platformName` (Android / iOS)
+- `udid` (hardcoded or parameterized)
+- `app` (app URL or `kobiton-store:` reference)
+- `sessionName`, `sessionDescription`
+- `automationName` (UiAutomator2, XCUITest, etc.)
+- `browserName` (if browser-based test)
+- `deviceOrientation`
+- Any `kobiton:*` vendor extensions (especially `kobiton:runtime`)
+
+## Reconciliation rules
+
+After running `scripts/render-capabilities.js`, compare its JSON output against the capabilities parsed from the user's script using these three categories:
+
+- **Must-match** (`platformName`, `platformVersion`, `appium:udid`, `appium:deviceName`, `appium:app` / `browserName`, `appium:automationName`): if different, show the user what will change and edit the script automatically. These must match the selected device/app or the Kobiton session will fail to start correctly.
+- **Suggested defaults** (`kobiton:sessionName`, `kobiton:sessionDescription`, `kobiton:deviceOrientation`, `kobiton:captureScreenshots`, `appium:noReset`, `appium:fullReset`): if different or missing, show the diff and ask the user before changing. The user may have intentionally set different values.
+- **User-controlled**: any capabilities in the user's script that are not in the rendered output - leave untouched. Never inject or modify `kobiton:runtime` unless the user explicitly asks.
+
+## See also
+
+- [`../SKILL.md`](../SKILL.md) - the orchestration skill that consumes this reference.
+- [Kobiton available capabilities reference](https://docs.kobiton.com/automation-testing/capabilities/available-capabilities) - canonical platform docs for `kobiton:*` and supported `appium:*` capabilities.
+- [Appium 2.x documentation](https://appium.io/docs/en/2.0/) - driver-specific capability docs (UiAutomator2, XCUITest).
+- [`../templates/appium.ejs`](templates/appium.ejs) - the EJS template `render-capabilities.js` uses to produce the rendered JSON.


### PR DESCRIPTION
## Summary

Moves three reference-grade blocks from `SKILL.md` into a new `skills/run-automation-suite/references/capabilities.md` so the main skill body stays lean — progressive disclosure per the Anthropic Skills spec. Final piece of the R1 audit batch from Intent Solutions (anchor: #20).

## Changes

- **New `skills/run-automation-suite/references/capabilities.md`** (45 lines) with 3 sections:
  - `## Runtime detection` — extension → runtime → common commands lookup + manifest-based runner selection note
  - `## Capability fields` — 8-field list of Appium/Kobiton capabilities to extract from a parsed script
  - `## Reconciliation rules` — must-match / suggested defaults / user-controlled categories for capability comparison
- **SKILL.md step 3 trimmed** — runtime table, capability fields list, and reconciliation rules replaced with relative-link references. Workflow prose stays inline (parse script, identify UDID, Appium runtime guardrail, render-capabilities command).
- **Backlink in capabilities.md `## See also`** points to `../SKILL.md` so the cross-reference is navigable both ways.

## Type of change

- [x] New skill files (added to `skills/run-automation-suite/references/`)
- [x] Plugin metadata update — skill body restructure

## Checklist

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes (22/22)
- [x] `render-capabilities.test.js` still resolves `references/templates/appium.ejs` (unchanged path)

## Related issues

Closes #13

Anchor: #20 (R1 audit batch reading order)
Stacks on: #31 (body structure) → #30 (frontmatter completeness)

## Notes for reviewers

- **Stacked on #31** - base branch is `fix/skill-body-structure-audit-r1`. When #31 merges, GitHub auto-rebases this PR to `main`. Sequential merge order: #30 → #31 → this PR. Merge in order to avoid rebase churn.
