### PR TITLE
docs(plugin): add support email + url to plugin and marketplace metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,9 @@
 {
   "name": "kobiton",
   "owner": {
-    "name": "Kobiton Inc."
+    "name": "Kobiton Inc.",
+    "email": "support@kobiton.com",
+    "url": "https://kobiton.com"
   },
   "metadata": {
     "description": "Kobiton mobile testing platform plugins for AI coding assistants",
@@ -13,8 +15,10 @@
       "version": "1.2.0",
       "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
       "author": {
-        "name": "Kobiton Inc."
+        "name": "Kobiton Inc.",
+        "email": "support@kobiton.com"
       },
+      "license": "MIT",
       "category": "testing",
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,8 @@
   "version": "1.2.0",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
-    "name": "Kobiton Inc."
+    "name": "Kobiton Inc.",
+    "email": "support@kobiton.com"
   },
   "license": "MIT",
   "repository": "https://github.com/kobiton/automate",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Plugin and marketplace metadata: surface support contact (`support@kobiton.com`) in `plugin.json` and `marketplace.json` author/owner blocks; add `license: MIT` and homepage URL on marketplace entries for marketplace consistency
+
 ## 1.2.0 - 2026-05-18
 
 - Multi-CLI support: install on GitHub Copilot CLI, Gemini CLI, and Codex CLI in addition to Claude Code


### PR DESCRIPTION
## Summary

Small metadata adds to `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` surfacing the support contact (`support@kobiton.com`) and Kobiton homepage in plugin-installable metadata.

## Changes

- `plugin.json` author block: add `email: support@kobiton.com`
- `marketplace.json` owner block: add `email` + `url: https://kobiton.com`
- `marketplace.json` plugin entry: add author `email` + `license: MIT` (mirrors `plugin.json`)
- `CHANGELOG.md`: noted under `## Unreleased`

## Type of change

- [ ] New tool (added to `tools/*.yaml`)
- [ ] New skill (added to `skills/`)
- [ ] Bug fix
- [x] Documentation update
- [ ] Validation/test update
- [x] Plugin metadata update

## Checklist

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes (no test files changed)
- [ ] New tools have `title`, `annotations`, and `inputSchema` (n/a — no new tools)
- [ ] New skills have YAML frontmatter with `name` and `description` (n/a — no new skills)
- [x] CHANGELOG.md updated (user-facing metadata change)
- [ ] README.md updated (n/a — no new tools/skills)

## Related issues

Refs: #53

## Why

Surfacing the support contact in installable plugin metadata helps users hitting auth or device-availability issues route their question directly, without having to dig through docs.kobiton.com first. License field on the plugin entry mirrors `plugin.json` for marketplace consistency.

## Context

First of three small PRs being staged in response to @mimosa767's #53 thread. The other two follow with the `## Authentication` section on `SKILL.md` and the architectural one-pager + Known Limitations reference file. This one is metadata-only and stands on its own.

Signed-off-by: Jeremy Longshore <jeremy@intentsolutions.io>
