### PR TITLE
docs(skill): add Authentication section + Write/sleep to allowed-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- `run-automation-suite` SKILL.md: new `## Authentication` section documenting the three `.mcp.*.json` variants (OAuth 2.1 default, API-key for CI, dev-local for Kobiton-internal). `allowed-tools` extended to include `Write` (for capability auto-edit in Step 3) and `Bash(sleep:*)` (for the Step 4 session-initialization wait)
-
 ## 1.2.0 - 2026-05-18
 
 - Multi-CLI support: install on GitHub Copilot CLI, Gemini CLI, and Codex CLI in addition to Claude Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `run-automation-suite` SKILL.md: new `## Authentication` section documenting the three `.mcp.*.json` variants (OAuth 2.1 default, API-key for CI, dev-local for Kobiton-internal). `allowed-tools` extended to include `Write` (for capability auto-edit in Step 3) and `Bash(sleep:*)` (for the Step 4 session-initialization wait)
+
 ## 1.2.0 - 2026-05-18
 
 - Multi-CLI support: install on GitHub Copilot CLI, Gemini CLI, and Codex CLI in addition to Claude Code

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -7,13 +7,13 @@ description: >-
   devices, or kick off an Appium suite from a local script directory.
   Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: >-
-  Read, Edit,
+  Read, Write, Edit,
   Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
   Bash(python:*), Bash(python3:*), Bash(pytest:*),
   Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
   Bash(dotnet:*),
   Bash(ruby:*), Bash(bundle:*), Bash(rspec:*),
-  Bash(open:*), Bash(xdg-open:*)
+  Bash(open:*), Bash(xdg-open:*), Bash(sleep:*)
 version: 1.0.2
 author: Kobiton Inc.
 license: MIT
@@ -40,6 +40,18 @@ Before invoking this skill, ensure:
 - **Runtime installed locally** - Node.js + npm/npx, Python + pip, Java + mvn/gradle, .NET SDK, or Ruby + bundle, whichever your test script uses.
 - **App build (or store reference)** - either a local `.apk` / `.ipa` / `.zip` build artifact for upload, or a `kobiton-store:vXXXXX` reference for an existing upload.
 - **Kobiton account** - credentials with device access for the target platform (Android / iOS) and remaining session quota.
+
+## Authentication
+
+This skill calls tools served by the Kobiton MCP server at `api.kobiton.com/mcp`. Three authentication configurations ship with the plugin; one of them must be active before any MCP tool will respond:
+
+| Config file | Auth mechanism | When to use |
+|---|---|---|
+| `.mcp.json` (default) | OAuth 2.1 browser flow | Interactive Claude Code session for an end user |
+| `.mcp.apikey-example.json` | Basic auth header — `Authorization: Basic base64(username:apikey)` from the `KOBITON_AUTH` env var | CI / headless / scripted invocations; copy this file over `.mcp.json` |
+| `.mcp.dev-local.json` | Direct connection to `localhost:3000/mcp` | Kobiton internal development against a local MCP server build |
+
+If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate via `claude mcp` before any device or session call can succeed. Do NOT attempt to recover by retrying — the auth context is fixed at session start.
 
 ## Instructions
 

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   devices, or kick off an Appium suite from a local script directory.
   Trigger with "run kobiton tests" or "execute appium on kobiton".
 allowed-tools: >-
-  Read, Write, Edit,
+  Read, Edit,
   Bash(node:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*),
   Bash(python:*), Bash(python3:*), Bash(pytest:*),
   Bash(java:*), Bash(mvn:*), Bash(gradle:*), Bash(./gradlew:*),
@@ -43,15 +43,14 @@ Before invoking this skill, ensure:
 
 ## Authentication
 
-This skill calls tools served by the Kobiton MCP server at `api.kobiton.com/mcp`. Three authentication configurations ship with the plugin; one of them must be active before any MCP tool will respond:
+This skill calls tools served by the Kobiton MCP server at `api.kobiton.com/mcp`. Two authentication configurations ship with the plugin; one of them must be active before any MCP tool will respond:
 
 | Config file | Auth mechanism | When to use |
 |---|---|---|
-| `.mcp.json` (default) | OAuth 2.1 browser flow | Interactive Claude Code session for an end user |
+| `.mcp.json` (default) | OAuth 2.1 browser flow | Interactive AI-CLI session for an end user |
 | `.mcp.apikey-example.json` | Basic auth header — `Authorization: Basic base64(username:apikey)` from the `KOBITON_AUTH` env var | CI / headless / scripted invocations; copy this file over `.mcp.json` |
-| `.mcp.dev-local.json` | Direct connection to `localhost:3000/mcp` | Kobiton internal development against a local MCP server build |
 
-If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate via `claude mcp` before any device or session call can succeed. Do NOT attempt to recover by retrying — the auth context is fixed at session start.
+If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate the Kobiton MCP server in their AI CLI before any device or session call can succeed. The exact invocation depends on the host (e.g. `/mcp` in Claude Code, `/mcp auth kobiton` in GitHub Copilot CLI and Gemini CLI, automatic browser flow on first tool call in Codex CLI — see the plugin README for current per-CLI commands). Do NOT attempt to recover by retrying — the auth context is fixed at session start.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary

Two narrow additions to `skills/run-automation-suite/SKILL.md`:

1. New `## Authentication` section (inserted after Prerequisites) documenting the three `.mcp.*.json` config variants the plugin ships with — so the agent has explicit auth-mode guidance at the top of the workflow rather than discovering it mid-run.
2. `allowed-tools` extended with `Write` and `Bash(sleep:*)` — both required by the existing skill body but missing from the allowlist.

Both changes are additive — no existing content rewritten.

## Changes

- `skills/run-automation-suite/SKILL.md` frontmatter: add `Write` and `Bash(sleep:*)` to the `allowed-tools` block-scalar
- `skills/run-automation-suite/SKILL.md` body: new `## Authentication` section between Prerequisites and Instructions, with a 3-row table of the config variants + the abort-on-no-MCP-connection guidance
- `CHANGELOG.md`: noted under `## Unreleased`

## Type of change

- [ ] New tool (added to `tools/*.yaml`)
- [ ] New skill (added to `skills/`)
- [ ] Bug fix
- [x] Documentation update
- [ ] Validation/test update
- [ ] Plugin metadata update

## Checklist

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes (no test files changed)
- [ ] New tools have `title`, `annotations`, and `inputSchema` (n/a — no new tools)
- [x] Existing skill has `name` and `description` (unchanged); frontmatter additions are within the existing skill
- [x] CHANGELOG.md updated (user-facing change)
- [ ] README.md updated (n/a — README is unchanged; skill-internal documentation only)

## Related issues

Refs: #53

## Why the `allowed-tools` changes

Without `Write` and `Bash(sleep:*)` in the allowlist, the agent has to ask the user permission mid-workflow which breaks the documented no-interruption execution flow:

- **`Write`** is needed alongside `Edit` for the auto-edit capability reconciliation in **Step 3** (must-match fields are autocorrected; this is a content-write to the user's test script when reconciling rendered capabilities against parsed-script capabilities).
- **`Bash(sleep:*)`** is needed for **Step 4**'s "wait 2 seconds (to allow the session to initialize on Kobiton)" before opening the browser.

Both are existing instructions in the skill body — the allowlist just hadn't caught up.

## Why the `## Authentication` section

The plugin ships with three `.mcp.*.json` variants but the skill currently assumes the user knows which config to use. New section documents the choice explicitly at the top of the workflow so the agent has a clear mental model when launching:

| Config file | Auth mechanism | When to use |
|---|---|---|
| `.mcp.json` (default) | OAuth 2.1 browser flow | Interactive Claude Code session |
| `.mcp.apikey-example.json` | Basic auth via `KOBITON_AUTH` env | CI / headless / scripted |
| `.mcp.dev-local.json` | Direct to `localhost:3000/mcp` | Kobiton-internal dev |

## Context

Second of three small PRs in response to @mimosa767's #53 thread. PR #63 (manifest metadata) was the first; PR 3 with the architectural one-pager + Known Limitations reference file follows.

Signed-off-by: Jeremy Longshore <jeremy@intentsolutions.io>
