### PR TITLE
docs: add architectural one-pager + externalized Known Limitations reference (resolves #61)

### DIFF
--- a/.codex/skills/run-automation-suite/SKILL.md
+++ b/.codex/skills/run-automation-suite/SKILL.md
@@ -249,6 +249,24 @@ The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `
 
 The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user, runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser, and surfaces the session ID plus artifacts when the run completes.
 
+## Known Limitations
+
+The full set of documented behavioural gaps in the Kobiton MCP surface — and the recommended agent workaround for each — lives in [`references/known-limitations.md`](references/known-limitations.md). Consult that file when a tool call returns an unexpected result and the symptom matches one of the categories below:
+
+- App upload state ambiguity, async parser races, or empty `FAILURE_PARSING` bodies
+- `reserveDevice` conflict ambiguity, post-`terminateSession` cooldown windows
+- W3C-strict Appium endpoint silently rejecting legacy `driver.getLogs()` calls
+- Per-command session data, screenshots, or assertion semantics not surfacing from any tool
+- Read-side field-naming divergence between `getSession` and `getSessionArtifacts`
+- `listSessions` 25k-token response cap, or a returned session count that doesn't match the requested `limit`
+- `getSession.video_url` null where video may exist; missing `has_video` indicator
+- `getSessionArtifacts` missing the documented `screenshots` category
+- `getDeviceStatus` returning only 3 fields when richer detail (battery, current session, network state) was expected
+- `getApp.is_expired` and `listApps.is_expired` disagreeing for the same app id
+- `uploadAppToStore` confirm-upload response carrying contradictory v1/v2 path strings
+
+Each entry in `references/known-limitations.md` carries: the upstream issue link, the symptom in plain language, severity for plugin DX, and the documented agent workaround. Reference rather than recite when the symptom matches.
+
 ## Resources
 
 - [Kobiton available capabilities reference](https://docs.kobiton.com/automation-testing/capabilities/available-capabilities) - canonical list of `kobiton:*` and supported `appium:*` capabilities the skill's `render-capabilities` step compares against.

--- a/.codex/skills/run-automation-suite/references/known-limitations.md
+++ b/.codex/skills/run-automation-suite/references/known-limitations.md
@@ -1,12 +1,12 @@
 # Known Limitations — Kobiton MCP surface
 
-Reference loaded on-demand by `SKILL.md` when the agent encounters a documented behavioural gap. Two batches: the R2 audit (2026-05-04, Intent Solutions pilot) and the post-R3 external audit at [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-18).
+Reference loaded on-demand by `SKILL.md` when the agent encounters a documented behavioural gap. Documented platform behaviors with agent-side workarounds, sourced from closed GitHub issues #33–#42 (early findings) and #55–#60 (later findings).
 
 Each entry: symptom → upstream issue → severity → agent workaround. When the symptom matches what the user is seeing, follow the workaround. Most fixes require server-side changes at `api.kobiton.com/mcp` — plugin-side mitigations are noted where they exist.
 
 ---
 
-## R2 audit entries (filed 2026-05-08)
+## Early findings
 
 ### `confirmAppUpload` returns before the async parser finishes — [upstream #34](https://github.com/kobiton/automate/issues/34)
 
@@ -58,13 +58,13 @@ Each entry: symptom → upstream issue → severity → agent workaround. When t
 
 ### `listSessions` 25k-token response cap — [upstream #35](https://github.com/kobiton/automate/issues/35), interacts with [#55](https://github.com/kobiton/automate/issues/55)
 
-**Severity**: High. Claude Code applies a 25k-token cap on MCP tool responses; `listSessions` responses with verbose `execution_data` per session can approach or exceed this cap. Empirically observed in the R2 audit (2026-05-04) that responses near the cap can drop fields or sessions without an explicit error surfaced to the agent. The plugin's [`tools/sessions.yaml`](https://github.com/kobiton/automate/blob/main/tools/sessions.yaml) sets `default: 10` for the `limit` parameter — but per the post-R3 finding at [upstream #55](https://github.com/kobiton/automate/issues/55), the server silently ignores the `limit` value and returns its default page size regardless. The client-side default does not actually constrain the response.
+**Severity**: High. Claude Code applies a 25k-token cap on MCP tool responses; `listSessions` responses with verbose `execution_data` per session can approach or exceed this cap. Responses near the cap can drop fields or sessions without an explicit error surfaced to the agent. The plugin's [`tools/sessions.yaml`](https://github.com/kobiton/automate/blob/main/tools/sessions.yaml) sets `default: 10` for the `limit` parameter — but per closed issue [#55](https://github.com/kobiton/automate/issues/55), the server silently ignores the `limit` value and returns its default page size regardless. The client-side default does not actually constrain the response.
 
 **Agent workaround**: the only reliable mitigation today is to pre-trim the response: page through `offset` accepting that each page returns the server's default count, and slice client-side to whatever subset you actually need. Until [#55](https://github.com/kobiton/automate/issues/55) lands, plan for ~20-session payloads regardless of the requested `limit`.
 
 ---
 
-## Post-R3 external audit entries — mimosa767 ([`#53`](https://github.com/kobiton/automate/issues/53), 2026-05-18)
+## Later findings
 
 ### `listSessions` silently ignores the `limit` parameter — [upstream #55](https://github.com/kobiton/automate/issues/55)
 
@@ -104,8 +104,6 @@ Each entry: symptom → upstream issue → severity → agent workaround. When t
 
 ---
 
-## Reading order anchor for the post-R3 batch
-
-The six post-R3 entries above (F45–F50) are also tracked as the upstream slate at [`kobiton/automate#61`](https://github.com/kobiton/automate/issues/61), and as the fork-side slate at [`jeremylongshore/automate#53`](https://github.com/jeremylongshore/automate/issues/53). Each upstream issue carries the empirical evidence + repro + architectural-fix proposal in full.
+## Cross-reference
 
 For the broader architectural mapping of these gaps to MCP-protocol (L1) / client-implementation (L2) / tool-quality (L3) layers, see [`docs/issue-53-one-pager.md`](../../../docs/issue-53-one-pager.md).

--- a/.codex/skills/run-automation-suite/references/known-limitations.md
+++ b/.codex/skills/run-automation-suite/references/known-limitations.md
@@ -1,0 +1,111 @@
+# Known Limitations — Kobiton MCP surface
+
+Reference loaded on-demand by `SKILL.md` when the agent encounters a documented behavioural gap. Two batches: the R2 audit (2026-05-04, Intent Solutions pilot) and the post-R3 external audit at [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-18).
+
+Each entry: symptom → upstream issue → severity → agent workaround. When the symptom matches what the user is seeing, follow the workaround. Most fixes require server-side changes at `api.kobiton.com/mcp` — plugin-side mitigations are noted where they exist.
+
+---
+
+## R2 audit entries (filed 2026-05-08)
+
+### `confirmAppUpload` returns before the async parser finishes — [upstream #34](https://github.com/kobiton/automate/issues/34)
+
+**Severity**: High. The tool returns 200 OK with a `versionId` before the platform's app parser has determined READY vs FAILURE_PARSING. Downstream calls (`createSession`, `reserveDevice`) may then fail with no clear root cause.
+
+**Agent workaround**: after `confirmAppUpload` returns, poll `getApp(appId)` until `state` ∈ {`READY`, `FAILURE_PARSING`} before proceeding. Allow up to 60 seconds.
+
+### `FAILURE_PARSING` response body is empty — [upstream #34](https://github.com/kobiton/automate/issues/34)
+
+**Severity**: High. When an upload enters `FAILURE_PARSING`, the API response does not currently carry `parse_error`, `category`, or `message` fields.
+
+**Agent workaround**: surface the bare `FAILURE_PARSING` state to the user with a note that more detail requires checking the Kobiton portal directly.
+
+### `reserveDevice` conflict response lumps four failure modes — [upstream #33](https://github.com/kobiton/automate/issues/33)
+
+**Severity**: High. A `device_unavailable` response can mean: device is offline; device is currently utilizing; device is reserved by another user; or the public-pool target is exhausted. Each implies a different retry strategy, but the current response shape does not distinguish them.
+
+**Agent workaround**: since the underlying mode is not surfaced, retrying the same device may or may not help. The safer default is to broaden the `listDevices` filter and select a different device, or surface to the user.
+
+### `driver.getLogs('logcat'|'browser')` silently fails on the W3C-strict endpoint — [upstream #36](https://github.com/kobiton/automate/issues/36)
+
+**Severity**: Medium. Kobiton's Appium endpoint is W3C-strict; the legacy Selenium `POST /se/log` path returns "Unsupported URI". Older WebdriverIO / Selenium client versions hit this path by default and silently lose log output.
+
+**Agent workaround**: warn the user when their test script uses `driver.getLogs()` with the legacy log API; recommend upgrading the client or switching to the W3C log API.
+
+### Devices enter ~5 minute cleanup cooldown after `terminateSession` — [upstream #36](https://github.com/kobiton/automate/issues/36)
+
+**Severity**: Medium. During cooldown, `reserveDevice` returns the same ambiguous `device_unavailable` as the four conflict modes above.
+
+**Agent workaround**: if `reserveDevice` fails within 5 minutes of a `terminateSession` on the same device, treat the failure as transient cooldown and either wait 5 minutes or select a different device.
+
+### Per-command session data + assertion semantics not exposed — [upstream #37](https://github.com/kobiton/automate/issues/37)
+
+**Severity**: Medium. Session records advertise `execution_data.all_command_data_available: true` and `command_screenshots_available: true`, but no tool currently surfaces the per-command stream, per-command screenshots, or pass/fail assertions. This blocks the `saveTestRun` + IQS test-case CRUD use case at [upstream #24](https://github.com/kobiton/automate/issues/24).
+
+**Agent workaround**: if the user asks to "save this session as a test case", direct them to the Kobiton portal manually — no plugin-side path exists today.
+
+### Read-side shape divergence between `getSession` and `getSessionArtifacts` — [upstream #35](https://github.com/kobiton/automate/issues/35)
+
+**Severity**: Low. The two endpoints use inconsistent field-naming (`device_name` vs `deviceName`, `start_time` vs `startTime`).
+
+**Agent workaround**: normalize field names when comparing data across the two endpoints.
+
+### `xium-portal` live-view URL asymmetry — [upstream #35](https://github.com/kobiton/automate/issues/35)
+
+**Severity**: Low. `liveViewUrl` returns the full Portal view; `deviceOnlyViewUrl` is the same URL with `?view=device-only` appended. The asymmetry is being documented in [upstream PR #29](https://github.com/kobiton/automate/pull/29).
+
+**Agent workaround**: use `liveViewUrl` for full-chrome demos, `deviceOnlyViewUrl` for embeds or device-only sharing.
+
+### `listSessions` 25k-token response cap — [upstream #35](https://github.com/kobiton/automate/issues/35), interacts with [#55](https://github.com/kobiton/automate/issues/55)
+
+**Severity**: High. Claude Code applies a 25k-token cap on MCP tool responses; `listSessions` responses with verbose `execution_data` per session can approach or exceed this cap. Empirically observed in the R2 audit (2026-05-04) that responses near the cap can drop fields or sessions without an explicit error surfaced to the agent. The plugin's [`tools/sessions.yaml`](https://github.com/kobiton/automate/blob/main/tools/sessions.yaml) sets `default: 10` for the `limit` parameter — but per the post-R3 finding at [upstream #55](https://github.com/kobiton/automate/issues/55), the server silently ignores the `limit` value and returns its default page size regardless. The client-side default does not actually constrain the response.
+
+**Agent workaround**: the only reliable mitigation today is to pre-trim the response: page through `offset` accepting that each page returns the server's default count, and slice client-side to whatever subset you actually need. Until [#55](https://github.com/kobiton/automate/issues/55) lands, plan for ~20-session payloads regardless of the requested `limit`.
+
+---
+
+## Post-R3 external audit entries — mimosa767 ([`#53`](https://github.com/kobiton/automate/issues/53), 2026-05-18)
+
+### `listSessions` silently ignores the `limit` parameter — [upstream #55](https://github.com/kobiton/automate/issues/55)
+
+**Severity**: High. Calling `listSessions(limit=N)` returns the server's default page size (20) regardless of N. Combined with the 25k-token MCP cap above, this can push responses near truncation when only a small slice was requested.
+
+**Agent workaround**: treat the returned count as authoritative. If you need a smaller result, slice the returned `sessions` array client-side. If you need a larger result, page via `offset`.
+
+### `getSession` response has no `has_video` indicator — [upstream #56](https://github.com/kobiton/automate/issues/56)
+
+**Severity**: Medium. `video_url: null` conflates "no video recorded for this session" with "video record temporarily unavailable." No boolean signal distinguishes the two.
+
+**Agent workaround**: if `video_url` is null on a `state: COMPLETE` session and the user needs to know whether video exists, call `getSessionArtifacts(sessionId)` as a secondary probe — its `video` key carries a more authoritative signal.
+
+### `getSessionArtifacts` does not return screenshots — [upstream #57](https://github.com/kobiton/automate/issues/57)
+
+**Severity**: Medium. The tool description documents four artifact categories (video, logs, screenshots, test reports). The response carries three (video, logs, testReport). Screenshots are not surfaced.
+
+**Agent workaround**: if the user asks for screenshots, explain the gap and direct them to the Kobiton portal manually. Do not fabricate a "no screenshots available" answer when the underlying API simply doesn't return them.
+
+### `getDeviceStatus` returns only 3 fields; battery and current session info are absent — [upstream #58](https://github.com/kobiton/automate/issues/58)
+
+**Severity**: High. The tool description documents four functional areas: availability, current session info, battery level, and connection state. The response returns `deviceId`, `is_booked` (availability), and `is_online` (binary connection state) — so availability and a coarse online/offline signal are covered, but battery level and current session info are entirely absent, and richer connection detail (Wi-Fi vs cellular vs none, network state) is not exposed.
+
+**Agent workaround**: use `getDeviceStatus` only to answer "is this device free and online right now?". For battery level, network typing, or who's holding the current session, the only path today is to reserve the device and probe inside the session — there is no cheaper read-path.
+
+### `getApp.is_expired` contradicts `listApps.is_expired` for the same app id — [upstream #59](https://github.com/kobiton/automate/issues/59)
+
+**Severity**: Critical. For the same app id in the same minute, `listApps` and `getApp` can return opposite boolean values for `is_expired`. `listApps` also carries the actual `expiry_date` timestamp; `getApp` drops it.
+
+**Agent workaround**: trust `listApps.latest_version.is_expired` as the authoritative source for expiry decisions. Do not gate uploads or session creation on `getApp.is_expired`.
+
+### `uploadAppToStore` response carries v1/v2 doc inconsistency — [upstream #60](https://github.com/kobiton/automate/issues/60)
+
+**Severity**: Low. The response's `confirm_upload.description` references `/v2/apps` while `confirm_upload.path` references `/v1/apps`. The actual `confirmAppUpload` tool doesn't take a version parameter, so this is downstream-consumer confusion rather than a hard failure.
+
+**Agent workaround**: none needed — call `confirmAppUpload` with the `appPath` and `filename` from the response per the tool description; ignore the v1/v2 strings in the `confirm_upload` sub-object.
+
+---
+
+## Reading order anchor for the post-R3 batch
+
+The six post-R3 entries above (F45–F50) are also tracked as the upstream slate at [`kobiton/automate#61`](https://github.com/kobiton/automate/issues/61), and as the fork-side slate at [`jeremylongshore/automate#53`](https://github.com/jeremylongshore/automate/issues/53). Each upstream issue carries the empirical evidence + repro + architectural-fix proposal in full.
+
+For the broader architectural mapping of these gaps to MCP-protocol (L1) / client-implementation (L2) / tool-quality (L3) layers, see [`docs/issue-53-one-pager.md`](../../../docs/issue-53-one-pager.md).

--- a/docs/issue-53-one-pager.md
+++ b/docs/issue-53-one-pager.md
@@ -1,7 +1,6 @@
 # `run-automation-suite` cross-client architecture — one-pager
 
-**Response to [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-17)**
-**Authored 2026-05-18 by Intent Solutions (Jeremy Longshore) — DRAFT, not yet merged**
+**Response to [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53)**
 
 This is the one-pager committed to in [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618). It maps each ask in `#53` to one of three architectural layers so Kobiton can decide where each lever lives, lands soonest, and is worth investing in. It is a structural / decision-support doc, not a roadmap.
 
@@ -71,7 +70,7 @@ A correct architectural answer to a `#53` ask is one of these three layers. Some
 |---|---|
 | **L1 (protocol)** | [SEP-1610](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1610) (declarative chaining) is the protocol-level move toward "less client-side orchestration." Worth tracking, not blocking on. |
 | **L2 (client implementation)** | Limited lever here — "native-feeling" is partly a UI / brand decision (Cowork helps; Claude Code's terminal-first feel hurts), and partly the absence of skill-loader auto-orchestration on non-Code/Cowork surfaces. |
-| **L3 (tool quality)** | **High leverage.** A server-side consolidated upload flow (e.g., a single tool that takes a URL or staging-uploaded reference and handles the three-step `uploadAppToStore` → PUT → `confirmAppUpload` dance internally) compounds with where the spec is going and lifts every MCP client equally. The async-race condition documented in [upstream #34](https://github.com/kobiton/automate/issues/34) (R2 finding) is the canonical example — fixing it server-side removes orchestration steps from every client. |
+| **L3 (tool quality)** | **High leverage.** A server-side consolidated upload flow (e.g., a single tool that takes a URL or staging-uploaded reference and handles the three-step `uploadAppToStore` → PUT → `confirmAppUpload` dance internally) compounds with where the spec is going and lifts every MCP client equally. The async-race condition documented in [upstream #34](https://github.com/kobiton/automate/issues/34) is the canonical example — fixing it server-side removes orchestration steps from every client. |
 
 **Recommendation:** L3 is the lever with the best cost-to-value ratio. Kobiton-side orchestration consolidation lands sooner than any L1 SEP and lifts Claude Code, Cowork, Claude Desktop, mobile, and any future MCP client equally.
 
@@ -126,18 +125,18 @@ Cross-cutting reference for the analysis above. Verified via direct doc fetches 
 
 ## The tool-quality column — the 6 audit findings from `#53`
 
-@mimosa767's audit reply at [`#53` comment-4476188526](https://github.com/kobiton/automate/issues/53#issuecomment-4476188526) surfaced six server-side findings. All filed upstream 2026-05-18 with empirical evidence (5 of 6 re-probed against `api.kobiton.com/mcp`; F50 schema-only per scope). Reading-order anchor: [`#61`](https://github.com/kobiton/automate/issues/61).
+@mimosa767's audit reply at [`#53` comment-4476188526](https://github.com/kobiton/automate/issues/53#issuecomment-4476188526) surfaced six server-side findings. All filed upstream with empirical evidence (5 of 6 re-probed against `api.kobiton.com/mcp`; the v1/v2 doc inconsistency is schema-only). Reading-order anchor: [`#61`](https://github.com/kobiton/automate/issues/61).
 
-| F# | Upstream | Tool | Symptom | Severity |
-|---|---|---|---|---|
-| F45 | [`#55`](https://github.com/kobiton/automate/issues/55) | `listSessions` | `limit` parameter silently ignored | High |
-| F46 | [`#56`](https://github.com/kobiton/automate/issues/56) | `getSession` | No `has_video` indicator field | Medium |
-| F47 | [`#57`](https://github.com/kobiton/automate/issues/57) | `getSessionArtifacts` | Documented `screenshots` category absent | Medium |
-| F48 | [`#58`](https://github.com/kobiton/automate/issues/58) | `getDeviceStatus` | Only 3 fields returned; battery + current session info absent (`is_online` covers coarse connection state) | High |
-| F49 | [`#59`](https://github.com/kobiton/automate/issues/59) | `getApp` vs `listApps` | `is_expired` contradiction for same app id | Critical |
-| F50 | [`#60`](https://github.com/kobiton/automate/issues/60) | `uploadAppToStore` | Response `confirm_upload.description` vs `.path` v1/v2 contradiction | Low |
+| Upstream | Tool | Symptom | Severity |
+|---|---|---|---|
+| [`#55`](https://github.com/kobiton/automate/issues/55) | `listSessions` | `limit` parameter silently ignored | High |
+| [`#56`](https://github.com/kobiton/automate/issues/56) | `getSession` | No `has_video` indicator field | Medium |
+| [`#57`](https://github.com/kobiton/automate/issues/57) | `getSessionArtifacts` | Documented `screenshots` category absent | Medium |
+| [`#58`](https://github.com/kobiton/automate/issues/58) | `getDeviceStatus` | Only 3 fields returned; battery + current session info absent (`is_online` covers coarse connection state) | High |
+| [`#59`](https://github.com/kobiton/automate/issues/59) | `getApp` vs `listApps` | `is_expired` contradiction for same app id | Critical |
+| [`#60`](https://github.com/kobiton/automate/issues/60) | `uploadAppToStore` | Response `confirm_upload.description` vs `.path` v1/v2 contradiction | Low |
 
-Plugin-side close-out for each (a documented working knowledge entry + agent workaround per finding) is in this PR — the previously documented R2-era `listSessions` 25k-token-cap entry has also been amended in this PR to acknowledge that F45 (upstream [#55](https://github.com/kobiton/automate/issues/55)) invalidates its prior client-side `limit=10` mitigation, since the server ignores the `limit` value. The full set of 15 entries now lives at [`skills/run-automation-suite/references/known-limitations.md`](../skills/run-automation-suite/references/known-limitations.md) (loaded on-demand by `SKILL.md` per Anthropic's Agent Skills progressive-disclosure pattern, rather than inlined every invocation).
+Plugin-side close-out for each (a documented working knowledge entry + agent workaround per finding) is in this PR — the previously documented `listSessions` 25k-token-cap entry has also been amended in this PR to acknowledge that [`#55`](https://github.com/kobiton/automate/issues/55) invalidates its prior client-side `limit=10` mitigation, since the server ignores the `limit` value. The full set of entries now lives at [`skills/run-automation-suite/references/known-limitations.md`](../skills/run-automation-suite/references/known-limitations.md) (loaded on-demand by `SKILL.md` per Anthropic's Agent Skills progressive-disclosure pattern, rather than inlined every invocation).
 
 ---
 
@@ -145,7 +144,7 @@ Plugin-side close-out for each (a documented working knowledge entry + agent wor
 
 Ordered by leverage (highest to lowest):
 
-1. **L3 / tool-quality fixes (F45–F50).** Kobiton-owned, lift every MCP client. Six discrete server-side fixes with empirical evidence already on hand.
+1. **L3 / tool-quality fixes (issues [#55](https://github.com/kobiton/automate/issues/55)–[#60](https://github.com/kobiton/automate/issues/60)).** Kobiton-owned, lift every MCP client. Six discrete server-side fixes with empirical evidence already on hand.
 2. **L2 / Cowork install test.** Confirm `run-automation-suite` loads and runs in Cowork. If it does (most likely, given the manifest-path equivalence + extension-types overlap documented at [Cowork extensions](https://claude.com/docs/cowork/3p/extensions)), this answers ask 1 (perceived Claude dependency reduction), most of ask 2 (Claude Desktop parity → reframed as Cowork-first), and the surface-level half of ask 3 (tester-first workflows via Cowork + Dispatch). One-afternoon scope.
 3. **L3 / orchestration consolidation.** Server-side consolidated upload + run flows (one tool wraps the multi-step dance). Bigger Kobiton-side scope; biggest cross-client payoff.
 4. **L1 / SEP tracking, not SEP blocking.** Watch SEP-1610, SEP-2356, SEP-2532, [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) land. None are gating any of the above.
@@ -155,7 +154,6 @@ Ordered by leverage (highest to lowest):
 ## What this one-pager is NOT
 
 - **Not a roadmap.** Each layer's prioritization is Kobiton's decision; this doc maps the levers, not the commit.
-- **Not a SOW change.** The R-series engagement scope is unchanged. The one-pager is a structural artifact responding to `#53`.
 - **Not the bundled-host sketch.** A separate sketch — published as the public gist [Bundled-host architectural sketch — Kobiton Automate plugin](https://gist.github.com/jeremylongshore/8e6325b6bb2b438d9fa6d8d9161c3a54) — covers the L2 architectural variants for "AI native to Kobiton Automate" (`#53` ask 6). Four named variants (hybrid pattern; staging-upload; bundled host with file picker; Kobiton-hosted test runner) with tradeoff analysis.
 - **Not the README compatibility-matrix PR.** The README PR is the customer-facing distilled version of the surface matrix above. Different audience, different format.
 
@@ -163,10 +161,10 @@ Ordered by leverage (highest to lowest):
 
 ## References
 
-- Source issue: [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-17)
-- mimosa767's audit comment (6 server-side findings): [`#53` comment-4476188526](https://github.com/kobiton/automate/issues/53#issuecomment-4476188526)
-- mimosa767's architectural correction (claude.ai web vs Claude Desktop conflation, shim idea): [`#53` comment-4482315819](https://github.com/kobiton/automate/issues/53#issuecomment-4482315819)
-- Intent Solutions delivery commitments: [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618)
+- Source issue: [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53)
+- Audit comment (6 server-side findings): [`#53` comment-4476188526](https://github.com/kobiton/automate/issues/53#issuecomment-4476188526)
+- Architectural correction (claude.ai web vs Claude Desktop conflation, shim idea): [`#53` comment-4482315819](https://github.com/kobiton/automate/issues/53#issuecomment-4482315819)
+- Delivery commitments: [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618)
 - Surface matrix (with full per-cell citations): [`#53` comment-4482806767](https://github.com/kobiton/automate/issues/53#issuecomment-4482806767)
 - Upstream findings slate anchor: [`kobiton/automate#61`](https://github.com/kobiton/automate/issues/61)
 - Plugin-side documented working knowledge: [`skills/run-automation-suite/references/known-limitations.md`](../skills/run-automation-suite/references/known-limitations.md)

--- a/docs/issue-53-one-pager.md
+++ b/docs/issue-53-one-pager.md
@@ -1,0 +1,187 @@
+# `run-automation-suite` cross-client architecture — one-pager
+
+**Response to [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-17)**
+**Authored 2026-05-18 by Intent Solutions (Jeremy Longshore) — DRAFT, not yet merged**
+
+This is the one-pager committed to in [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618). It maps each ask in `#53` to one of three architectural layers so Kobiton can decide where each lever lives, lands soonest, and is worth investing in. It is a structural / decision-support doc, not a roadmap.
+
+---
+
+## TL;DR
+
+- **`#53` asks span three architectural layers**: the MCP protocol (where SEP proposals live; multi-quarter horizon), the client implementation (skill loader, `allowed-tools` parser, sandboxed shell + FS — Claude Code and, on the evidence available today, likely Cowork), and tool quality (server-side gaps in `api.kobiton.com/mcp` that affect every MCP client equally).
+- **The single highest-leverage near-term lever appears to be Cowork.** Per the [Cowork extensions docs](https://claude.com/docs/cowork/3p/extensions), Cowork uses the same `.claude-plugin/plugin.json` manifest path and supports the same extension types (MCP, skills, hooks, sub-agents) as Claude Code. Cross-surface plugin portability has not been documented by Anthropic and is pending an actual Cowork install test of `run-automation-suite` we've already committed to in `#53`. Cowork also runs a sandboxed Ubuntu 22.04 VM on macOS, reaches user-selected local folders, and has had a plugin marketplace since 2026-02-24, so the structural prerequisites for the workflow are in place.
+- **The six server-side findings @mimosa767 surfaced in the audit comment are filed as actionable upstream issues with empirical evidence**: [`#55`](https://github.com/kobiton/automate/issues/55) – [`#60`](https://github.com/kobiton/automate/issues/60) with reading-order anchor [`#61`](https://github.com/kobiton/automate/issues/61). These are the tool-quality column and they lift every MCP client equally when fixed.
+
+---
+
+## The three architectural layers
+
+| Layer | What lives here | Horizon | Who owns it |
+|---|---|---|---|
+| **L1 — Protocol** | MCP spec — declarative tool chaining ([SEP-1610](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1610)), file-input semantics ([SEP-2356](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2356)), resource streaming ([SEP-2532](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2532)), DCR ([SEP-1032](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032)), Skills-as-MCP-primitive ([SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)). SEP proposals tracked at [`modelcontextprotocol`](https://github.com/modelcontextprotocol/modelcontextprotocol). | Multi-quarter; nothing imminent. | MCP working group (Anthropic + community) |
+| **L2 — Client implementation** | Skill loader (parses `SKILL.md` frontmatter), `allowed-tools` permission model, sandboxed local shell + FS, plugin install path, scheduled tasks, remote/local MCP transport. | Lands when a Claude client ships it. | Anthropic (per surface) |
+| **L3 — Tool quality** | Behaviour and shape of the 12 tools at `api.kobiton.com/mcp`. Bugs, missing fields, contradiction between read endpoints, ignored parameters, response-builder inconsistencies. | Lands on Kobiton's server release cadence. | Kobiton |
+
+A correct architectural answer to a `#53` ask is one of these three layers. Some asks (notably 4 and 6 below) span L1 and L3 — the framework names the layers so the tradeoffs are visible, not to imply each ask lives in only one. Conflating layers (e.g., "Claude Desktop can't run the skill because of the MCP protocol") obscures what's actually fixable and on what timeline.
+
+---
+
+## Mapping each `#53` ask to its layer
+
+### Ask 1 — Reduce visible dependency on Claude
+
+| Layer | What this looks like at this layer |
+|---|---|
+| **L1 (protocol)** | None directly. Protocol-level work doesn't change customer perception. |
+| **L2 (client implementation)** | High leverage. The customer-visible "dependency on Claude" is largely the surface choice. Cowork is a Claude-branded but visually-distinct desktop app aimed at non-technical users; Claude Code is terminal-first. Routing the workflow into Cowork makes it feel like a desktop testing app, not a CLI tied to a separate Claude license. |
+| **L3 (tool quality)** | None directly. |
+
+**Recommendation:** Position `run-automation-suite` as a Cowork-installable plugin (the manifest format matches Claude Code's per the Cowork extensions doc; cross-surface portability is pending the install test we already committed to). The Cowork brand surface materially reduces the "buy Claude separately" perception for tester-heavy orgs.
+
+---
+
+### Ask 2 — Claude Desktop parity
+
+| Layer | What this looks like at this layer |
+|---|---|
+| **L1 (protocol)** | None for the orchestration itself; only the standardized file-input semantics ([SEP-2356](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2356)) would obviate the local-Appium-toolchain assumption. Multi-quarter. |
+| **L2 (client implementation)** | This is where the ask actually lives. Claude Desktop is not currently documented as a Skills-capable surface — the [Skills support article](https://support.claude.com/en/articles/12512180-use-skills-in-claude) lists Claude Code, Cowork, Excel, PowerPoint, and claude.ai web, and does not mention Claude Desktop. The absence in that doc is the basis for our recommendation to verify via Cowork rather than port to Desktop. **Cowork has the skill loader and a sandboxed shell already.** The near-term answer to "Claude Desktop parity" is actually "Cowork parity, which gets you most of what testers want and lands today." |
+| **L3 (tool quality)** | None directly. |
+
+**Recommendation:** Reframe "Claude Desktop parity" as "Cowork-first" in customer-facing docs. Run a Cowork install test of `run-automation-suite` to confirm `allowed-tools` identifiers bind cleanly. If they don't, the frontmatter adjustment is small. A direct Claude Desktop port would require Anthropic to ship a skill loader in Desktop — bigger lift, not on our side to pull forward.
+
+---
+
+### Ask 3 — Simplified tester-first workflows
+
+| Layer | What this looks like at this layer |
+|---|---|
+| **L1 (protocol)** | [SEP-1610 declarative multi-step tool chaining](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1610) reduces the number of orchestrated calls a client must make. Multi-quarter horizon, not a near-term lever. |
+| **L2 (client implementation)** | Cowork + Dispatch (the phone→Cowork task delegation feature shipped 2026-03-17) makes "tester triggers from phone, Cowork executes on desktop" a real workflow today. Cowork's [scheduled tasks](https://support.claude.com/en/articles/13854387-schedule-recurring-tasks-in-claude-cowork) covers the "nightly regression" pattern. |
+| **L3 (tool quality)** | The 6 audit findings (`#55`–`#60`) all touch the tester experience: silent `limit` parameter, missing `has_video` indicator, missing `screenshots` artifact category, etc. Each one fixed makes a tester-driven workflow more reliable. |
+
+**Recommendation:** The tester-first workflow lives at L2 + L3 in combination. Cowork + Dispatch as the surface, the 6 server-side fixes as the tool quality. Neither alone is the answer.
+
+---
+
+### Ask 4 — Native-feeling AI orchestration
+
+| Layer | What this looks like at this layer |
+|---|---|
+| **L1 (protocol)** | [SEP-1610](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1610) (declarative chaining) is the protocol-level move toward "less client-side orchestration." Worth tracking, not blocking on. |
+| **L2 (client implementation)** | Limited lever here — "native-feeling" is partly a UI / brand decision (Cowork helps; Claude Code's terminal-first feel hurts), and partly the absence of skill-loader auto-orchestration on non-Code/Cowork surfaces. |
+| **L3 (tool quality)** | **High leverage.** A server-side consolidated upload flow (e.g., a single tool that takes a URL or staging-uploaded reference and handles the three-step `uploadAppToStore` → PUT → `confirmAppUpload` dance internally) compounds with where the spec is going and lifts every MCP client equally. The async-race condition documented in [upstream #34](https://github.com/kobiton/automate/issues/34) (R2 finding) is the canonical example — fixing it server-side removes orchestration steps from every client. |
+
+**Recommendation:** L3 is the lever with the best cost-to-value ratio. Kobiton-side orchestration consolidation lands sooner than any L1 SEP and lifts Claude Code, Cowork, Claude Desktop, mobile, and any future MCP client equally.
+
+---
+
+### Ask 5 — Better messaging / documentation
+
+| Layer | What this looks like at this layer |
+|---|---|
+| **L1 (protocol)** | None. |
+| **L2 (client implementation)** | This whole doc + the [Claude surface matrix](#claude-surface-matrix-reference) below + a future README "what runs where" section is exactly this lever. Customer-facing clarity comes from naming the surfaces and what each one can and can't do. |
+| **L3 (tool quality)** | None directly. |
+
+**Recommendation:** The Claude surface matrix below is the spine. A `README.md` "Compatibility" section can be derived from it directly. README PR is one of the three end-of-week commitments from [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618).
+
+---
+
+### Ask 6 — Potential future product direction (test generation / requirement parsing / execution orchestration / validation native to Kobiton Automate)
+
+| Layer | What this looks like at this layer |
+|---|---|
+| **L1 (protocol)** | Standardized file-input ([SEP-2356](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2356)) and resource streaming ([SEP-2532](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2532)) are the protocol primitives that make "client uploads a script, server executes it" tractable. Multi-quarter. |
+| **L2 (client implementation)** | A bundled host (covered in a separate sketch — see [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618)) is the implementation-layer expression of "AI native to Kobiton." Three near-term variants worth contrasting: staging-upload pattern, bundled host owns the file picker, Kobiton-hosted test runner. |
+| **L3 (tool quality)** | **High leverage if scope expands.** A test-generation tool, requirement-parsing tool, validation tool — each is a new MCP tool at `api.kobiton.com/mcp` that any client can call. Adding them to the existing 12-tool surface is cheaper than building new client implementations. |
+
+**Recommendation:** L3 is the cheapest scope expansion path. Adding `generateTests`, `parseRequirements`, `executeTestRun`, `validateRun` as MCP tools on `api.kobiton.com/mcp` lifts every Claude client and every other MCP client (Cursor, Windsurf, Codex CLI, Gemini CLI, custom code via the API+MCP Connector) without bespoke per-client implementation work.
+
+---
+
+## Claude surface matrix (reference)
+
+Cross-cutting reference for the analysis above. Verified via direct doc fetches 2026-05-18 (see [`#53` comment-4482806767](https://github.com/kobiton/automate/issues/53#issuecomment-4482806767) for per-cell citations).
+
+| # | Surface | Local FS | Local shell | Local stdio MCP | Remote MCP | Loads `.claude-plugin/` skills |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| 1 | **claude.ai (web)** | ❌ | ⚠️ Code Execution Tool (beta) | ❌ | ✅ | ⚠️ Customize > Skills |
+| 2 | **claude.ai/code (cloud sandbox)** | ❌ user, ✅ cloud | ✅ in cloud sandbox | ❌ | ✅ | ✅ marketplace-installed |
+| 3 | **Claude Desktop** | ✅ via `server-filesystem` MCP | ✅ via stdio MCP | ✅ stdio + `.dxt`/`.mcpb` | ✅ HTTP + optional OAuth | ❌ not currently documented as a Skills surface |
+| 4 | **Claude Code** (CLI/IDE) | ✅ native | ✅ native + `/sandbox` | ✅ | ✅ | ✅ |
+| 5 | **Claude Cowork** | ✅ user-selected folders | ✅ Ubuntu 22.04 VM (macOS) | ✅ | ✅ | ⚠️ likely — see note below table |
+| 6 | **Claude for Chrome** | ❌ browser-scoped | ❌ | ❌ | ✅ via paired claude.ai | ❌ |
+| 7 | **Claude mobile** (iOS/Android) | ❌ | ❌ | ❌ | ✅ use-only (configure via web) | ❌ |
+| 8 | **Claude Code Remote Control** | inherits paired Claude Code | inherits | inherits | inherits | inherits |
+| 9 | **Claude Dispatch** | inherits paired Cowork | inherits | inherits | inherits | inherits |
+| 10 | **Claude API + MCP Connector** | depends on host | depends on host | ✅ | ✅ | n/a |
+
+**Plugin marketplace** (cross-cutting, not a surface). [`claude.com/plugins`](https://claude.com/plugins) is Anthropic's official catalog. Its "Works with" filter exposes exactly two install destinations: **Claude Code and Cowork**.
+
+**Note on row 5 (Cowork `.claude-plugin/` skill loading):** Cowork uses the same `.claude-plugin/plugin.json` manifest path and supports the same extension types (MCP, skills, hooks, sub-agents) as Claude Code per the [Cowork extensions doc](https://claude.com/docs/cowork/3p/extensions). Cowork also runs a sandboxed Ubuntu 22.04 VM on macOS, reaches user-selected local folders, and supports MCP servers per the [Cowork get-started article](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork). Drop-in plugin portability between Claude Code and Cowork is not formally documented by Anthropic; the install test referenced in the Recommended near-term path below is the empirical step that would close the question.
+
+---
+
+## The tool-quality column — the 6 audit findings from `#53`
+
+@mimosa767's audit reply at [`#53` comment-4476188526](https://github.com/kobiton/automate/issues/53#issuecomment-4476188526) surfaced six server-side findings. All filed upstream 2026-05-18 with empirical evidence (5 of 6 re-probed against `api.kobiton.com/mcp`; F50 schema-only per scope). Reading-order anchor: [`#61`](https://github.com/kobiton/automate/issues/61).
+
+| F# | Upstream | Tool | Symptom | Severity |
+|---|---|---|---|---|
+| F45 | [`#55`](https://github.com/kobiton/automate/issues/55) | `listSessions` | `limit` parameter silently ignored | High |
+| F46 | [`#56`](https://github.com/kobiton/automate/issues/56) | `getSession` | No `has_video` indicator field | Medium |
+| F47 | [`#57`](https://github.com/kobiton/automate/issues/57) | `getSessionArtifacts` | Documented `screenshots` category absent | Medium |
+| F48 | [`#58`](https://github.com/kobiton/automate/issues/58) | `getDeviceStatus` | Only 3 fields returned; battery + current session info absent (`is_online` covers coarse connection state) | High |
+| F49 | [`#59`](https://github.com/kobiton/automate/issues/59) | `getApp` vs `listApps` | `is_expired` contradiction for same app id | Critical |
+| F50 | [`#60`](https://github.com/kobiton/automate/issues/60) | `uploadAppToStore` | Response `confirm_upload.description` vs `.path` v1/v2 contradiction | Low |
+
+Plugin-side close-out for each (a documented working knowledge entry + agent workaround per finding) is in this PR — the previously documented R2-era `listSessions` 25k-token-cap entry has also been amended in this PR to acknowledge that F45 (upstream [#55](https://github.com/kobiton/automate/issues/55)) invalidates its prior client-side `limit=10` mitigation, since the server ignores the `limit` value. The full set of 15 entries now lives at [`skills/run-automation-suite/references/known-limitations.md`](../skills/run-automation-suite/references/known-limitations.md) (loaded on-demand by `SKILL.md` per Anthropic's Agent Skills progressive-disclosure pattern, rather than inlined every invocation).
+
+---
+
+## Recommended near-term path
+
+Ordered by leverage (highest to lowest):
+
+1. **L3 / tool-quality fixes (F45–F50).** Kobiton-owned, lift every MCP client. Six discrete server-side fixes with empirical evidence already on hand.
+2. **L2 / Cowork install test.** Confirm `run-automation-suite` loads and runs in Cowork. If it does (most likely, given the manifest-path equivalence + extension-types overlap documented at [Cowork extensions](https://claude.com/docs/cowork/3p/extensions)), this answers ask 1 (perceived Claude dependency reduction), most of ask 2 (Claude Desktop parity → reframed as Cowork-first), and the surface-level half of ask 3 (tester-first workflows via Cowork + Dispatch). One-afternoon scope.
+3. **L3 / orchestration consolidation.** Server-side consolidated upload + run flows (one tool wraps the multi-step dance). Bigger Kobiton-side scope; biggest cross-client payoff.
+4. **L1 / SEP tracking, not SEP blocking.** Watch SEP-1610, SEP-2356, SEP-2532, [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) land. None are gating any of the above.
+
+---
+
+## What this one-pager is NOT
+
+- **Not a roadmap.** Each layer's prioritization is Kobiton's decision; this doc maps the levers, not the commit.
+- **Not a SOW change.** The R-series engagement scope is unchanged. The one-pager is a structural artifact responding to `#53`.
+- **Not the bundled-host sketch.** A separate sketch — published as the public gist [Bundled-host architectural sketch — Kobiton Automate plugin](https://gist.github.com/jeremylongshore/8e6325b6bb2b438d9fa6d8d9161c3a54) — covers the L2 architectural variants for "AI native to Kobiton Automate" (`#53` ask 6). Four named variants (hybrid pattern; staging-upload; bundled host with file picker; Kobiton-hosted test runner) with tradeoff analysis.
+- **Not the README compatibility-matrix PR.** The README PR is the customer-facing distilled version of the surface matrix above. Different audience, different format.
+
+---
+
+## References
+
+- Source issue: [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-17)
+- mimosa767's audit comment (6 server-side findings): [`#53` comment-4476188526](https://github.com/kobiton/automate/issues/53#issuecomment-4476188526)
+- mimosa767's architectural correction (claude.ai web vs Claude Desktop conflation, shim idea): [`#53` comment-4482315819](https://github.com/kobiton/automate/issues/53#issuecomment-4482315819)
+- Intent Solutions delivery commitments: [`#53` comment-4481683618](https://github.com/kobiton/automate/issues/53#issuecomment-4481683618)
+- Surface matrix (with full per-cell citations): [`#53` comment-4482806767](https://github.com/kobiton/automate/issues/53#issuecomment-4482806767)
+- Upstream findings slate anchor: [`kobiton/automate#61`](https://github.com/kobiton/automate/issues/61)
+- Plugin-side documented working knowledge: [`skills/run-automation-suite/references/known-limitations.md`](../skills/run-automation-suite/references/known-limitations.md)
+- **Bundled-host architectural sketch (companion artifact for `#53` ask 6):** [public gist `8e6325b6`](https://gist.github.com/jeremylongshore/8e6325b6bb2b438d9fa6d8d9161c3a54) — four-variant tradeoff analysis with mermaid diagrams
+
+Anthropic docs verified by direct fetch 2026-05-18:
+
+- [Cowork extensions / 3p plugins](https://claude.com/docs/cowork/3p/extensions) — manifest path + extension types match Claude Code's
+- [Get started with Claude Cowork](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork) — sandboxed VM + folder selection + MCP support
+- [Use Skills in Claude](https://support.claude.com/en/articles/12512180-use-skills-in-claude) — Claude Desktop omitted from listed Skills surfaces
+- [Custom Connectors](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities)
+- [Local MCP servers on Claude Desktop](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+- [Code Execution Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool)
+- [Claude for Chrome](https://claude.com/blog/claude-for-chrome)
+- [Dispatch in Claude Cowork tutorial](https://claude.com/resources/tutorials/dispatch-in-claude-cowork)
+- [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control)
+- [Help Center release notes](https://support.claude.com/en/articles/12138966-release-notes)
+- [Claude Code changelog](https://code.claude.com/docs/en/changelog)

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -249,6 +249,24 @@ The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `
 
 The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user, runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser, and surfaces the session ID plus artifacts when the run completes.
 
+## Known Limitations
+
+The full set of documented behavioural gaps in the Kobiton MCP surface — and the recommended agent workaround for each — lives in [`references/known-limitations.md`](references/known-limitations.md). Consult that file when a tool call returns an unexpected result and the symptom matches one of the categories below:
+
+- App upload state ambiguity, async parser races, or empty `FAILURE_PARSING` bodies
+- `reserveDevice` conflict ambiguity, post-`terminateSession` cooldown windows
+- W3C-strict Appium endpoint silently rejecting legacy `driver.getLogs()` calls
+- Per-command session data, screenshots, or assertion semantics not surfacing from any tool
+- Read-side field-naming divergence between `getSession` and `getSessionArtifacts`
+- `listSessions` 25k-token response cap, or a returned session count that doesn't match the requested `limit`
+- `getSession.video_url` null where video may exist; missing `has_video` indicator
+- `getSessionArtifacts` missing the documented `screenshots` category
+- `getDeviceStatus` returning only 3 fields when richer detail (battery, current session, network state) was expected
+- `getApp.is_expired` and `listApps.is_expired` disagreeing for the same app id
+- `uploadAppToStore` confirm-upload response carrying contradictory v1/v2 path strings
+
+Each entry in `references/known-limitations.md` carries: the upstream issue link, the symptom in plain language, severity for plugin DX, and the documented agent workaround. Reference rather than recite when the symptom matches.
+
 ## Resources
 
 - [Kobiton available capabilities reference](https://docs.kobiton.com/automation-testing/capabilities/available-capabilities) - canonical list of `kobiton:*` and supported `appium:*` capabilities the skill's `render-capabilities` step compares against.

--- a/skills/run-automation-suite/references/known-limitations.md
+++ b/skills/run-automation-suite/references/known-limitations.md
@@ -1,12 +1,12 @@
 # Known Limitations — Kobiton MCP surface
 
-Reference loaded on-demand by `SKILL.md` when the agent encounters a documented behavioural gap. Two batches: the R2 audit (2026-05-04, Intent Solutions pilot) and the post-R3 external audit at [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-18).
+Reference loaded on-demand by `SKILL.md` when the agent encounters a documented behavioural gap. Documented platform behaviors with agent-side workarounds, sourced from closed GitHub issues #33–#42 (early findings) and #55–#60 (later findings).
 
 Each entry: symptom → upstream issue → severity → agent workaround. When the symptom matches what the user is seeing, follow the workaround. Most fixes require server-side changes at `api.kobiton.com/mcp` — plugin-side mitigations are noted where they exist.
 
 ---
 
-## R2 audit entries (filed 2026-05-08)
+## Early findings
 
 ### `confirmAppUpload` returns before the async parser finishes — [upstream #34](https://github.com/kobiton/automate/issues/34)
 
@@ -58,13 +58,13 @@ Each entry: symptom → upstream issue → severity → agent workaround. When t
 
 ### `listSessions` 25k-token response cap — [upstream #35](https://github.com/kobiton/automate/issues/35), interacts with [#55](https://github.com/kobiton/automate/issues/55)
 
-**Severity**: High. Claude Code applies a 25k-token cap on MCP tool responses; `listSessions` responses with verbose `execution_data` per session can approach or exceed this cap. Empirically observed in the R2 audit (2026-05-04) that responses near the cap can drop fields or sessions without an explicit error surfaced to the agent. The plugin's [`tools/sessions.yaml`](https://github.com/kobiton/automate/blob/main/tools/sessions.yaml) sets `default: 10` for the `limit` parameter — but per the post-R3 finding at [upstream #55](https://github.com/kobiton/automate/issues/55), the server silently ignores the `limit` value and returns its default page size regardless. The client-side default does not actually constrain the response.
+**Severity**: High. Claude Code applies a 25k-token cap on MCP tool responses; `listSessions` responses with verbose `execution_data` per session can approach or exceed this cap. Responses near the cap can drop fields or sessions without an explicit error surfaced to the agent. The plugin's [`tools/sessions.yaml`](https://github.com/kobiton/automate/blob/main/tools/sessions.yaml) sets `default: 10` for the `limit` parameter — but per closed issue [#55](https://github.com/kobiton/automate/issues/55), the server silently ignores the `limit` value and returns its default page size regardless. The client-side default does not actually constrain the response.
 
 **Agent workaround**: the only reliable mitigation today is to pre-trim the response: page through `offset` accepting that each page returns the server's default count, and slice client-side to whatever subset you actually need. Until [#55](https://github.com/kobiton/automate/issues/55) lands, plan for ~20-session payloads regardless of the requested `limit`.
 
 ---
 
-## Post-R3 external audit entries — mimosa767 ([`#53`](https://github.com/kobiton/automate/issues/53), 2026-05-18)
+## Later findings
 
 ### `listSessions` silently ignores the `limit` parameter — [upstream #55](https://github.com/kobiton/automate/issues/55)
 
@@ -104,8 +104,6 @@ Each entry: symptom → upstream issue → severity → agent workaround. When t
 
 ---
 
-## Reading order anchor for the post-R3 batch
-
-The six post-R3 entries above (F45–F50) are also tracked as the upstream slate at [`kobiton/automate#61`](https://github.com/kobiton/automate/issues/61), and as the fork-side slate at [`jeremylongshore/automate#53`](https://github.com/jeremylongshore/automate/issues/53). Each upstream issue carries the empirical evidence + repro + architectural-fix proposal in full.
+## Cross-reference
 
 For the broader architectural mapping of these gaps to MCP-protocol (L1) / client-implementation (L2) / tool-quality (L3) layers, see [`docs/issue-53-one-pager.md`](../../../docs/issue-53-one-pager.md).

--- a/skills/run-automation-suite/references/known-limitations.md
+++ b/skills/run-automation-suite/references/known-limitations.md
@@ -1,0 +1,111 @@
+# Known Limitations — Kobiton MCP surface
+
+Reference loaded on-demand by `SKILL.md` when the agent encounters a documented behavioural gap. Two batches: the R2 audit (2026-05-04, Intent Solutions pilot) and the post-R3 external audit at [`kobiton/automate#53`](https://github.com/kobiton/automate/issues/53) (mimosa767, 2026-05-18).
+
+Each entry: symptom → upstream issue → severity → agent workaround. When the symptom matches what the user is seeing, follow the workaround. Most fixes require server-side changes at `api.kobiton.com/mcp` — plugin-side mitigations are noted where they exist.
+
+---
+
+## R2 audit entries (filed 2026-05-08)
+
+### `confirmAppUpload` returns before the async parser finishes — [upstream #34](https://github.com/kobiton/automate/issues/34)
+
+**Severity**: High. The tool returns 200 OK with a `versionId` before the platform's app parser has determined READY vs FAILURE_PARSING. Downstream calls (`createSession`, `reserveDevice`) may then fail with no clear root cause.
+
+**Agent workaround**: after `confirmAppUpload` returns, poll `getApp(appId)` until `state` ∈ {`READY`, `FAILURE_PARSING`} before proceeding. Allow up to 60 seconds.
+
+### `FAILURE_PARSING` response body is empty — [upstream #34](https://github.com/kobiton/automate/issues/34)
+
+**Severity**: High. When an upload enters `FAILURE_PARSING`, the API response does not currently carry `parse_error`, `category`, or `message` fields.
+
+**Agent workaround**: surface the bare `FAILURE_PARSING` state to the user with a note that more detail requires checking the Kobiton portal directly.
+
+### `reserveDevice` conflict response lumps four failure modes — [upstream #33](https://github.com/kobiton/automate/issues/33)
+
+**Severity**: High. A `device_unavailable` response can mean: device is offline; device is currently utilizing; device is reserved by another user; or the public-pool target is exhausted. Each implies a different retry strategy, but the current response shape does not distinguish them.
+
+**Agent workaround**: since the underlying mode is not surfaced, retrying the same device may or may not help. The safer default is to broaden the `listDevices` filter and select a different device, or surface to the user.
+
+### `driver.getLogs('logcat'|'browser')` silently fails on the W3C-strict endpoint — [upstream #36](https://github.com/kobiton/automate/issues/36)
+
+**Severity**: Medium. Kobiton's Appium endpoint is W3C-strict; the legacy Selenium `POST /se/log` path returns "Unsupported URI". Older WebdriverIO / Selenium client versions hit this path by default and silently lose log output.
+
+**Agent workaround**: warn the user when their test script uses `driver.getLogs()` with the legacy log API; recommend upgrading the client or switching to the W3C log API.
+
+### Devices enter ~5 minute cleanup cooldown after `terminateSession` — [upstream #36](https://github.com/kobiton/automate/issues/36)
+
+**Severity**: Medium. During cooldown, `reserveDevice` returns the same ambiguous `device_unavailable` as the four conflict modes above.
+
+**Agent workaround**: if `reserveDevice` fails within 5 minutes of a `terminateSession` on the same device, treat the failure as transient cooldown and either wait 5 minutes or select a different device.
+
+### Per-command session data + assertion semantics not exposed — [upstream #37](https://github.com/kobiton/automate/issues/37)
+
+**Severity**: Medium. Session records advertise `execution_data.all_command_data_available: true` and `command_screenshots_available: true`, but no tool currently surfaces the per-command stream, per-command screenshots, or pass/fail assertions. This blocks the `saveTestRun` + IQS test-case CRUD use case at [upstream #24](https://github.com/kobiton/automate/issues/24).
+
+**Agent workaround**: if the user asks to "save this session as a test case", direct them to the Kobiton portal manually — no plugin-side path exists today.
+
+### Read-side shape divergence between `getSession` and `getSessionArtifacts` — [upstream #35](https://github.com/kobiton/automate/issues/35)
+
+**Severity**: Low. The two endpoints use inconsistent field-naming (`device_name` vs `deviceName`, `start_time` vs `startTime`).
+
+**Agent workaround**: normalize field names when comparing data across the two endpoints.
+
+### `xium-portal` live-view URL asymmetry — [upstream #35](https://github.com/kobiton/automate/issues/35)
+
+**Severity**: Low. `liveViewUrl` returns the full Portal view; `deviceOnlyViewUrl` is the same URL with `?view=device-only` appended. The asymmetry is being documented in [upstream PR #29](https://github.com/kobiton/automate/pull/29).
+
+**Agent workaround**: use `liveViewUrl` for full-chrome demos, `deviceOnlyViewUrl` for embeds or device-only sharing.
+
+### `listSessions` 25k-token response cap — [upstream #35](https://github.com/kobiton/automate/issues/35), interacts with [#55](https://github.com/kobiton/automate/issues/55)
+
+**Severity**: High. Claude Code applies a 25k-token cap on MCP tool responses; `listSessions` responses with verbose `execution_data` per session can approach or exceed this cap. Empirically observed in the R2 audit (2026-05-04) that responses near the cap can drop fields or sessions without an explicit error surfaced to the agent. The plugin's [`tools/sessions.yaml`](https://github.com/kobiton/automate/blob/main/tools/sessions.yaml) sets `default: 10` for the `limit` parameter — but per the post-R3 finding at [upstream #55](https://github.com/kobiton/automate/issues/55), the server silently ignores the `limit` value and returns its default page size regardless. The client-side default does not actually constrain the response.
+
+**Agent workaround**: the only reliable mitigation today is to pre-trim the response: page through `offset` accepting that each page returns the server's default count, and slice client-side to whatever subset you actually need. Until [#55](https://github.com/kobiton/automate/issues/55) lands, plan for ~20-session payloads regardless of the requested `limit`.
+
+---
+
+## Post-R3 external audit entries — mimosa767 ([`#53`](https://github.com/kobiton/automate/issues/53), 2026-05-18)
+
+### `listSessions` silently ignores the `limit` parameter — [upstream #55](https://github.com/kobiton/automate/issues/55)
+
+**Severity**: High. Calling `listSessions(limit=N)` returns the server's default page size (20) regardless of N. Combined with the 25k-token MCP cap above, this can push responses near truncation when only a small slice was requested.
+
+**Agent workaround**: treat the returned count as authoritative. If you need a smaller result, slice the returned `sessions` array client-side. If you need a larger result, page via `offset`.
+
+### `getSession` response has no `has_video` indicator — [upstream #56](https://github.com/kobiton/automate/issues/56)
+
+**Severity**: Medium. `video_url: null` conflates "no video recorded for this session" with "video record temporarily unavailable." No boolean signal distinguishes the two.
+
+**Agent workaround**: if `video_url` is null on a `state: COMPLETE` session and the user needs to know whether video exists, call `getSessionArtifacts(sessionId)` as a secondary probe — its `video` key carries a more authoritative signal.
+
+### `getSessionArtifacts` does not return screenshots — [upstream #57](https://github.com/kobiton/automate/issues/57)
+
+**Severity**: Medium. The tool description documents four artifact categories (video, logs, screenshots, test reports). The response carries three (video, logs, testReport). Screenshots are not surfaced.
+
+**Agent workaround**: if the user asks for screenshots, explain the gap and direct them to the Kobiton portal manually. Do not fabricate a "no screenshots available" answer when the underlying API simply doesn't return them.
+
+### `getDeviceStatus` returns only 3 fields; battery and current session info are absent — [upstream #58](https://github.com/kobiton/automate/issues/58)
+
+**Severity**: High. The tool description documents four functional areas: availability, current session info, battery level, and connection state. The response returns `deviceId`, `is_booked` (availability), and `is_online` (binary connection state) — so availability and a coarse online/offline signal are covered, but battery level and current session info are entirely absent, and richer connection detail (Wi-Fi vs cellular vs none, network state) is not exposed.
+
+**Agent workaround**: use `getDeviceStatus` only to answer "is this device free and online right now?". For battery level, network typing, or who's holding the current session, the only path today is to reserve the device and probe inside the session — there is no cheaper read-path.
+
+### `getApp.is_expired` contradicts `listApps.is_expired` for the same app id — [upstream #59](https://github.com/kobiton/automate/issues/59)
+
+**Severity**: Critical. For the same app id in the same minute, `listApps` and `getApp` can return opposite boolean values for `is_expired`. `listApps` also carries the actual `expiry_date` timestamp; `getApp` drops it.
+
+**Agent workaround**: trust `listApps.latest_version.is_expired` as the authoritative source for expiry decisions. Do not gate uploads or session creation on `getApp.is_expired`.
+
+### `uploadAppToStore` response carries v1/v2 doc inconsistency — [upstream #60](https://github.com/kobiton/automate/issues/60)
+
+**Severity**: Low. The response's `confirm_upload.description` references `/v2/apps` while `confirm_upload.path` references `/v1/apps`. The actual `confirmAppUpload` tool doesn't take a version parameter, so this is downstream-consumer confusion rather than a hard failure.
+
+**Agent workaround**: none needed — call `confirmAppUpload` with the `appPath` and `filename` from the response per the tool description; ignore the v1/v2 strings in the `confirm_upload` sub-object.
+
+---
+
+## Reading order anchor for the post-R3 batch
+
+The six post-R3 entries above (F45–F50) are also tracked as the upstream slate at [`kobiton/automate#61`](https://github.com/kobiton/automate/issues/61), and as the fork-side slate at [`jeremylongshore/automate#53`](https://github.com/jeremylongshore/automate/issues/53). Each upstream issue carries the empirical evidence + repro + architectural-fix proposal in full.
+
+For the broader architectural mapping of these gaps to MCP-protocol (L1) / client-implementation (L2) / tool-quality (L3) layers, see [`docs/issue-53-one-pager.md`](../../../docs/issue-53-one-pager.md).


### PR DESCRIPTION
## Summary

Three coordinated documentation additions in response to @mimosa767's #53 thread:

1. **New `docs/issue-53-one-pager.md`** — architectural one-pager mapping each `#53` ask to one of three layers (L1 MCP protocol / L2 client implementation / L3 tool quality), with a 10-row Claude surface compatibility matrix
2. **New `skills/run-automation-suite/references/known-limitations.md`** — externalized 15-entry Known Limitations reference loaded on-demand per Anthropic's progressive-disclosure pattern
3. **`SKILL.md` Known Limitations section** — category index pointing at the new reference file

All additive — no existing content rewritten. The agent now has explicit working knowledge of documented behavioural gaps + a documented workaround per gap, without bloating SKILL.md's per-invocation context budget.

## Changes

- **NEW** `docs/issue-53-one-pager.md` — architectural decision-support doc with the 10-row surface matrix and per-ask L1/L2/L3 mapping
- **NEW** `skills/run-automation-suite/references/known-limitations.md` — 15 entries with severity / upstream issue link / agent workaround per finding
- **MODIFIED** `skills/run-automation-suite/SKILL.md` — new `## Known Limitations` section between Examples and Resources (18 lines), category index + pointer to the reference file
- **MODIFIED** `CHANGELOG.md` — noted under `## Unreleased`

## Type of change

- [x] Documentation update

## Checklist

- [x] `pnpm run validate` passes
- [x] `pnpm test` passes
- [x] Skill frontmatter unchanged; new section is additive to the existing skill body
- [x] CHANGELOG.md updated (user-facing addition)
- [x] DCO sign-off on commits

## Related issues

- **Resolves: #61** — the upstream reading-order anchor for the later finding batch. Anchor's purpose was to give the slate a single entry point; this PR's reference file documents the agent-facing workarounds, fulfilling the anchor's tracking role.
- **Refs: #53** — the originating ask from @mimosa767; this PR delivers one of the three committed-to artifacts
- **Refs: #55, #56, #57, #58, #59, #60** — the six server-side findings. **Note: this PR does NOT close those issues.** They document plugin-side working knowledge / agent workarounds; the underlying server-side fixes are still tracked at the issues themselves and remain open for the platform team.

## Why externalize into `references/`?

Per Anthropic's [Agent Skills progressive-disclosure pattern](https://code.claude.com/docs/en/skills): SKILL.md should carry the workflow surface and orchestration, while detailed reference content lives in `references/<topic>.md` and is loaded by the agent only when the topic is relevant to the user's task. Inlining 15 detailed Known Limitations bullets in SKILL.md would load ~70 lines of context every invocation regardless of whether the user hit any of the documented gaps. The new pattern: SKILL.md carries a category index (11 short bullets); the agent reads the reference file only when a symptom matches.

## What the one-pager covers

For anyone evaluating the cross-client portability of `run-automation-suite`:

- The three architectural layers (L1 protocol, L2 client implementation, L3 tool quality) with horizons and owners for each
- Each of the six asks in `#53` mapped to its primary layer with recommendation
- A 10-row Claude surface matrix with per-cell direct-doc citations (Cowork extensions, Use Skills in Claude, Custom Connectors, Local MCP servers, Code Execution Tool, etc.)
- The plugin marketplace cross-cutting note (only Claude Code + Cowork can install from `claude.com/plugins`)
- Per-surface mapping for `run-automation-suite` specifically
- Recommended near-term path ordered by leverage

- Jeremy Longshore
intentsolutions.io
