### PR TITLE
docs(readme): add Claude surface compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,23 @@ For CI/CD pipelines or headless environments that cannot open a browser, use API
 
 </details>
 
+## Claude surface compatibility
+
+Different Claude surfaces (Claude Code, Cowork, Claude Desktop, the claude.ai web app, mobile) expose different capabilities, so the same plugin behaves differently depending on where it's installed. Quick reference for "what works where":
+
+| Claude surface | Atomic MCP tools (`listDevices`, `reserveDevice`, `getSession`, …) | Orchestrated skills (`run-automation-suite`, `run-interactive-test` ¹) | Setup |
+|---|:---:|:---:|---|
+| **Claude Code** (CLI / IDE) | ✅ | ✅ | `/plugin marketplace add kobiton/automate` then `/plugin install automate@kobiton` |
+| **Claude Cowork** (macOS / Windows desktop) | ✅ | ⚠️ install-test pending | Cowork uses the same `.claude-plugin/plugin.json` manifest path + extension types as Claude Code per [Cowork extensions docs](https://claude.com/docs/cowork/3p/extensions); confirming drop-in portability is on the engagement-close checklist |
+| **claude.ai (web)** | ✅ via Custom Connector | ❌ | Add `https://api.kobiton.com/mcp` as a Custom Connector at [claude.ai](https://claude.ai); the skill loader for `.claude-plugin/` skills does not run on the web surface |
+| **Claude Desktop** (macOS / Windows app) | ✅ via Custom Connector | ❌ | Add the Kobiton MCP as a Custom Connector; Claude Desktop is not currently documented as a Skills-capable surface in Anthropic's [Use Skills in Claude](https://support.claude.com/en/articles/12512180-use-skills-in-claude) doc |
+| **Claude mobile** (iOS / Android) | ✅ via Custom Connector | ❌ | Configure the Custom Connector on claude.ai (web) first; tools sync into the mobile app for use |
+| **Other MCP clients** (Cursor, Gemini CLI, Codex CLI, ChatGPT Apps SDK, Continue, Cline, …) | ✅ | ❌ | See [Installation](#installation) above for the four already-documented clients; Cursor / ChatGPT / Continue / Cline configs are in the "Other MCP Clients" subsection |
+
+The take-home: **every Claude surface that supports MCP can call the atomic Kobiton tools.** The orchestrated skills — `run-automation-suite` (Appium test script execution) and `run-interactive-test` (natural-language WebDriver / device commands via the bundled `kobiton` CLI) — are Claude-Code-today; Cowork is the next likely landing point once the install test confirms cross-surface portability.
+
+¹ `run-interactive-test` additionally requires the bundled `kobiton` CLI binary (macOS only); on other host OSes use `run-automation-suite` or the MCP tools directly.
+
 ## Getting Started
 
 After installation, run setup to fetch your credentials and write them to `~/.kobiton/.credentials`:


### PR DESCRIPTION
## Summary

Adds a customer-facing "Claude surface compatibility" section to the README between the Login and Getting Started sections, answering **"what works where"** across Claude Code, Cowork, the claude.ai web app, Claude Desktop, Claude mobile, and other MCP clients.

This came out of [issue #53](https://github.com/kobiton/automate/issues/53) — a recurring question about which Claude surfaces can actually consume the plugin. The matrix puts that answer in front of customers without needing them to read the Anthropic docs.

## Changes

- New "Claude surface compatibility" section in `README.md` — 6-row matrix with two axes:
  - **Atomic MCP tools** (`listDevices`, `reserveDevice`, `getSession`, …) — every Claude surface that supports MCP can call these, via the marketplace install on Claude Code / Copilot CLI / Gemini CLI / Codex CLI, or via a Custom Connector pointing at `api.kobiton.com/mcp` on the Anthropic-hosted surfaces (claude.ai web, Desktop, mobile)
  - **Orchestrated `run-automation-suite` skill** — Claude-Code-today; Cowork install-test pending; not loaded by the web / Desktop / mobile surfaces because the `.claude-plugin/` skill loader does not run there
- Per-cell wording cites Anthropic's published docs (Cowork extensions doc; "Use Skills in Claude" support article) rather than overstating what those docs establish.
- `CHANGELOG.md`: `## Unreleased` entry.

No changes to runtime behavior. README extension only.

## Type of change

- [x] Documentation update

## Checklist

- [x] \`pnpm run validate\` passes
- [x] \`pnpm test\` passes (38 tests)
- [ ] New tools have \`title\`, \`annotations\` (\`readOnlyHint\`, \`destructiveHint\`), and \`inputSchema\` — n/a
- [ ] New skills have YAML frontmatter with \`name\` and \`description\` — n/a
- [x] CHANGELOG.md updated
- [x] README.md updated (new "Claude surface compatibility" section)

## Related issues

Mirrors closed fork PR [jeremylongshore/automate#57](https://github.com/jeremylongshore/automate/pull/57). The cross-link to `docs/issue-53-one-pager.md` is omitted here; that one-pager lives in a separate workstream — already open as [#65](https://github.com/kobiton/automate/pull/65) — and the matrix stands on its own as a 6-row reference.

The "Other MCP clients" row references the "Other MCP Clients" subsection added by [#68](https://github.com/kobiton/automate/pull/68); merging this PR after #68 avoids a broken anchor.

Refs: kobiton/automate#53

Signed-off-by: Jeremy Longshore <jeremy@intentsolutions.io>

- Jeremy Longshore
intentsolutions.io