### PR TITLE
feat(tools): add idempotentHint + openWorldHint annotations to all 12 tools

### DIFF
--- a/tools/apps.yaml
+++ b/tools/apps.yaml
@@ -8,7 +8,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object
@@ -112,7 +111,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object

--- a/tools/apps.yaml
+++ b/tools/apps.yaml
@@ -8,6 +8,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -46,6 +48,8 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -79,6 +83,8 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -106,6 +112,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:

--- a/tools/devices.yaml
+++ b/tools/devices.yaml
@@ -9,7 +9,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object
@@ -61,7 +60,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object
@@ -118,7 +116,7 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: true
-      idempotentHint: false
+      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object

--- a/tools/devices.yaml
+++ b/tools/devices.yaml
@@ -9,6 +9,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -59,6 +61,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -84,6 +88,8 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -112,6 +118,8 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: true
+      idempotentHint: false
+      openWorldHint: false
     inputSchema:
       type: object
       properties:

--- a/tools/sessions.yaml
+++ b/tools/sessions.yaml
@@ -8,7 +8,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object
@@ -66,7 +65,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object
@@ -91,7 +89,6 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
-      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object
@@ -116,7 +113,7 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: true
-      idempotentHint: false
+      idempotentHint: true
       openWorldHint: false
     inputSchema:
       type: object

--- a/tools/sessions.yaml
+++ b/tools/sessions.yaml
@@ -8,6 +8,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -64,6 +66,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -87,6 +91,8 @@ tools:
     annotations:
       readOnlyHint: true
       destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
     inputSchema:
       type: object
       properties:
@@ -110,6 +116,8 @@ tools:
     annotations:
       readOnlyHint: false
       destructiveHint: true
+      idempotentHint: false
+      openWorldHint: false
     inputSchema:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Add `idempotentHint` + `openWorldHint` annotations to all 12 tools across `tools/apps.yaml`, `tools/devices.yaml`, and `tools/sessions.yaml`.

Per the [MCP tool-annotations spec](https://modelcontextprotocol.io/docs/specification/2025-06-18/server/tools#tool-annotations), non-Claude MCP clients (Cursor, ChatGPT Apps SDK, Continue/Cline, Gemini CLI, Codex CLI, etc.) reason about side-effect classes using these annotations. Today the plugin declares only `readOnlyHint` + `destructiveHint`; clients that rely on idempotency or world-state semantics fall back to conservative defaults.

## Annotation matrix

Uniform `openWorldHint: false` since the Kobiton MCP server is a bounded API surface.

| Verb pattern | `idempotentHint` | Rationale |
|---|---|---|
| `list*` | `true` | Read, repeatable |
| `get*` | `true` | Read, repeatable |
| `getCredential` | `true` | Read, no state mutation |
| `reserveDevice` | `false` | Allocates resource |
| `uploadAppToStore` | `false` | Creates new app version |
| `confirmAppUpload` | `true` | Per F25 finding: a second call after success is a lookup, not a duplicate upload trigger |
| `terminate*` | `false` | State-changing destructive op |

## Files

| File | Tools affected |
|---|---|
| `tools/apps.yaml` | 4 (listApps, uploadAppToStore, confirmAppUpload, getApp) |
| `tools/devices.yaml` | 4 (listDevices, getDeviceStatus, reserveDevice, terminateReservation) |
| `tools/sessions.yaml` | 4 (listSessions, getSession, getSessionArtifacts, terminateSession) |

24 lines added; no existing fields modified. Mirror of fork PR #42.

## Validation

- `pnpm run validate` passes
- DCO sign-off included on the commit

## What this PR does NOT include

`outputSchema` declarations — would require empirical server-response captures per the existing F-finding cluster, and is folded into the forthcoming `docs/server-side-recommendations.md` (separate close-out PR).

## Relationship to engagement deliverables

- **R3 § 4 Bundle 2**: this is the plugin-side tool-annotation completion. The MCP-spec-conformance cluster (`#39`, closed) addresses the server-side spec primitives (instructions, resources/*, prompts/*); this PR completes the annotation surface on the tool side.
- **Cross-client surface**: pairs with upstream PR #68 (cross-client install paths) and PR #69 (Claude surface compatibility matrix) — non-Claude clients now see meaningful side-effect semantics on every tool.

Refs `kobiton/automate#39` (closed; F36-F38 MCP-spec-conformance cluster).

- Jeremy Longshore
intentsolutions.io
