### PR TITLE
docs: consistency cleanup — AGENTS.md + version alignment + README sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,22 @@
 # AGENTS.md — Kobiton Automate
 
-Cross-tool agent instructions for the Kobiton mobile testing platform's MCP plugin. This file is the host-agnostic equivalent of `skills/run-automation-suite/SKILL.md` — it's read by Gemini CLI (via `contextFileName`), Codex CLI, GitHub Copilot CLI, ChatGPT Apps SDK, and other agentic CLIs that don't consume Claude Code's skill format.
+Cross-tool agent instructions for the Kobiton mobile testing platform's MCP plugin. This file is the host-agnostic equivalent of `skills/run-automation-suite/SKILL.md` — it's read by Gemini CLI (via `contextFileName`), GitHub Copilot CLI, and Cursor CLI. (Codex CLI reads the mirrored `.codex/skills/*/SKILL.md` instead; Claude Code reads `skills/*/SKILL.md` directly.)
 
 ## What this plugin does
 
-Kobiton is a real-device mobile cloud for Android + iOS testing. This MCP plugin gives AI agents 12 tools to:
+Kobiton is a real-device mobile cloud for Android + iOS testing. This MCP plugin gives AI agents 28 tools to:
 
-- **Devices** — list, get status, reserve, terminate reservation
-- **Apps** — list, upload, confirm upload, get details
-- **Sessions** — list, get, get artifacts, terminate
+- **Devices** (4) — list, get status, reserve, terminate reservation
+- **Apps** (4) — list, upload, confirm upload, get details
+- **Sessions** (5) — list, get, get artifacts, get user-input events, terminate
+- **Test management** (14) — create / list / get / update / delete test cases, test runs, and test suites; `saveTestCase` converts a finished manual session into a reusable test case
+- **Setup** (1) — `getCredential` (used by `/automate:setup`)
 
 The MCP server runs at `https://api.kobiton.com/mcp`. Authentication is OAuth 2.1 (default) or API key (CI/headless).
+
+## userIntent format
+
+Every tool call requires a `userIntent` argument summarizing what the user is trying to accomplish — a natural-language sentence is sufficient (e.g., `"reserve a Pixel 7 to run the checkout suite"`). The plugin's audit logging consumes this; include it on every tool call.
 
 ## When the user asks to run tests on Kobiton
 
@@ -24,33 +30,45 @@ Default workflow (matches the `run-automation-suite` skill for Claude Code users
 
 Detailed step-by-step instructions live in `skills/run-automation-suite/SKILL.md` — read those if you support Claude Code's skill format.
 
+## When the user asks to interactively drive a device
+
+For exploratory testing or repro work (not running a pre-written script):
+
+1. **Pick a device** — same `listDevices` flow as above; the user is interactively in the loop.
+2. **Create or resume a session** — `reserveDevice` then start an interactive session; resume an existing one by session ID if the user has one.
+3. **Interact** — relay WebDriver commands through the plugin; capture artifacts on demand.
+4. **End the session** — `terminateSession` when the user is done.
+
+Detailed step-by-step instructions live in `skills/run-interactive-test/SKILL.md`. Response shapes for the WebDriver layer are documented at `skills/run-interactive-test/references/response-shapes.md`.
+
+## When the user asks to save or manage test cases
+
+The plugin exposes 14 test-management tools covering test cases, test runs, and test suites. The most common ask is *"save the session I just ran as a reusable test case"* — for that, call `saveTestCase` with the session ID and a name. The remaining tools follow standard CRUD patterns (`createTestRun` / `listTestCases` / `getTestSuite` / `updateTestCase` / `deleteTestRun` etc.). For multi-step orchestration, ask the user to confirm before any `delete*` or `terminateTestRun` call.
+
 ## Known limitations
 
-Several behaviors of the current Kobiton MCP server have known gaps that agents should plan around (full details with workarounds in `skills/run-automation-suite/SKILL.md` § "Known Limitations"):
+Several behaviors of the current Kobiton MCP server have known gaps that agents should plan around:
 
 - **`confirmAppUpload` async race** — returns 200 OK before the parser finishes. Poll `getApp(appId)` until state is `READY` or `FAILURE_PARSING` before downstream calls.
 - **`reserveDevice` ambiguous conflict** — `device_unavailable` lumps 4 failure modes. Don't retry the same device; broaden the filter and pick a different device.
 - **W3C `/se/log` silently breaks legacy `driver.getLogs()`** — Kobiton's Appium endpoint is W3C-strict. Warn the user if their test script uses the legacy log API.
-- **`deleteSession` ~5min cooldown** — device enters cleanup after termination; `reserveDevice` on the same device may return `device_unavailable` for ~5min.
-- **Per-command session data not exposed** — no plugin-side way to save a session as a test case; direct the user to the Kobiton portal manually.
-
-## userIntent format
-
-Every tool call requires a `userIntent` argument summarizing what the user is trying to accomplish — a natural-language sentence is sufficient (e.g., `"reserve a Pixel 7 to run the checkout suite"`). The plugin's audit logging consumes this.
+- **`terminateSession` ~5min device cooldown** — after termination the device enters cleanup; `reserveDevice` on the same device may return `device_unavailable` for ~5min.
 
 ## Cross-host install
 
+Plugin install paths for every supported host (listed for reference; only Gemini / Copilot / Cursor consume this `AGENTS.md` as agent context):
+
 | Host | Install path |
 |---|---|
-| Claude Code | `/plugin install automate@kobiton` (uses `.mcp.json` + `skills/` + `agents/` + `hooks/`) |
-| Gemini CLI | `gemini extensions install kobiton/automate` (uses `gemini-extension.json` + this `AGENTS.md`) |
-| Cursor | Add `.cursor/mcp.json` config (see README) |
-| Codex CLI | `~/.codex/config.toml` (see README) |
+| Claude Code | `/plugin marketplace add kobiton/automate` then `/plugin install automate@kobiton` (uses `.mcp.json` + `skills/` + `hooks/`) |
+| Gemini CLI | `gemini extensions install https://github.com/kobiton/automate` (uses `gemini-extension.json` + this `AGENTS.md`) |
+| Cursor CLI / IDE | `/plugin marketplace add github.com/kobiton/automate`, then install (commands surface as `/setup` + `/doctor`) |
+| Codex CLI | `codex plugin marketplace add kobiton/automate`, then install from the plugin browser (Codex reads `.codex/skills/*/SKILL.md`, not this file) |
 | GitHub Copilot CLI | See README install section |
 | ChatGPT Apps SDK | Add `https://api.kobiton.com/mcp` in ChatGPT developer mode |
 | Continue / Cline | Add to `~/.continue/config.json` or equivalent (see README) |
 
-Hooks (the `hooks/` directory) and the `agents/` directory are Claude Code-specific today; other hosts will ignore them.
+The `hooks/` directory is Claude Code-specific today; other hosts will ignore it.
 
 ## Reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,72 @@
-# Kobiton Automate
+# AGENTS.md — Kobiton Automate
 
-This plugin connects to the Kobiton mobile testing platform via MCP. It provides tools for managing devices, apps, and test sessions.
+Cross-tool agent instructions for the Kobiton mobile testing platform's MCP plugin. This file is the host-agnostic equivalent of `skills/run-automation-suite/SKILL.md` — it's read by Gemini CLI (via `contextFileName`), Codex CLI, GitHub Copilot CLI, ChatGPT Apps SDK, and other agentic CLIs that don't consume Claude Code's skill format.
 
-## Available Tools
+## What this plugin does
 
-Use these MCP tools for device, session, and app management:
+Kobiton is a real-device mobile cloud for Android + iOS testing. This MCP plugin gives AI agents 12 tools to:
 
-- **Devices:** `listDevices`, `getDeviceStatus`, `reserveDevice`, `terminateReservation`
-- **Sessions:** `listSessions`, `getSession`, `getSessionArtifacts`, `terminateSession`
-- **Apps:** `listApps`, `getApp`, `uploadAppToStore`, `confirmAppUpload`
+- **Devices** — list, get status, reserve, terminate reservation
+- **Apps** — list, upload, confirm upload, get details
+- **Sessions** — list, get, get artifacts, terminate
 
-## Running Automation Tests
+The MCP server runs at `https://api.kobiton.com/mcp`. Authentication is OAuth 2.1 (default) or API key (CI/headless).
 
-Use the **run-automation-suite** skill for guided test execution. It walks through app upload, device selection, Appium script parsing, and local execution with result collection.
+## When the user asks to run tests on Kobiton
 
-## Authentication
+Default workflow (matches the `run-automation-suite` skill for Claude Code users):
 
-Authentication is handled by the MCP server. Connect to the `kobiton` MCP server to authenticate via OAuth or API key.
+1. **Identify the app** — ask the user whether to upload a new app build or reuse an existing one. Do NOT auto-upload without confirmation.
+2. **Select a device** — call `listDevices` with the right platform filter. Confirm with the user before reserving.
+3. **Parse capabilities** — read the local Appium test script (Node / Python / .NET / Java), extract the capabilities literal, reconcile against the selected device per the must-match / suggested-default / user-controlled policy in `skills/run-automation-suite/references/capabilities.md`.
+4. **Confirm and execute** — present the summary, get user confirmation, run the script in the background, open the live-view URL.
+5. **Collect artifacts** — after the session terminates, call `getSession` + `getSessionArtifacts` for video, logs, screenshots, test reports. Surface session link + pass/fail.
+
+Detailed step-by-step instructions live in `skills/run-automation-suite/SKILL.md` — read those if you support Claude Code's skill format.
+
+## Known limitations
+
+Several behaviors of the current Kobiton MCP server have known gaps that agents should plan around (full details with workarounds in `skills/run-automation-suite/SKILL.md` § "Known Limitations"):
+
+- **`confirmAppUpload` async race** — returns 200 OK before the parser finishes. Poll `getApp(appId)` until state is `READY` or `FAILURE_PARSING` before downstream calls.
+- **`reserveDevice` ambiguous conflict** — `device_unavailable` lumps 4 failure modes. Don't retry the same device; broaden the filter and pick a different device.
+- **W3C `/se/log` silently breaks legacy `driver.getLogs()`** — Kobiton's Appium endpoint is W3C-strict. Warn the user if their test script uses the legacy log API.
+- **`deleteSession` ~5min cooldown** — device enters cleanup after termination; `reserveDevice` on the same device may return `device_unavailable` for ~5min.
+- **Per-command session data not exposed** — no plugin-side way to save a session as a test case; direct the user to the Kobiton portal manually.
+
+## userIntent format
+
+Every tool call requires a `userIntent` argument summarizing what the user is trying to accomplish. The plugin's audit logging consumes this.
+
+For automated / pipeline use, the strict format is:
+
+```
+[partner=<name>] <verb-phrase, 20-80 chars> | contact:<email>
+```
+
+For interactive end-users, a short natural-language summary is fine:
+
+```
+"reserve a Pixel 7 to run the checkout suite"
+```
+
+## Cross-host install
+
+| Host | Install path |
+|---|---|
+| Claude Code | `/plugin install automate@kobiton` (uses `.mcp.json` + `skills/` + `agents/` + `hooks/`) |
+| Gemini CLI | `gemini extensions install kobiton/automate` (uses `gemini-extension.json` + this `AGENTS.md`) |
+| Cursor | Add `.cursor/mcp.json` config (see README) |
+| Codex CLI | `~/.codex/config.toml` (see README) |
+| GitHub Copilot CLI | See README install section |
+| ChatGPT Apps SDK | Add `https://api.kobiton.com/mcp` in ChatGPT developer mode |
+| Continue / Cline | Add to `~/.continue/config.json` or equivalent (see README) |
+
+Hooks (the `hooks/` directory) and the `agents/` directory are Claude Code-specific today; other hosts will ignore them.
+
+## Reference
+
+- Plugin source: https://github.com/kobiton/automate
+- Kobiton platform documentation: https://docs.kobiton.com
+- Appium 2.x: https://appium.io
+- MCP specification: https://modelcontextprotocol.io/specification/2025-06-18

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,19 +36,7 @@ Several behaviors of the current Kobiton MCP server have known gaps that agents 
 
 ## userIntent format
 
-Every tool call requires a `userIntent` argument summarizing what the user is trying to accomplish. The plugin's audit logging consumes this.
-
-For automated / pipeline use, the strict format is:
-
-```
-[partner=<name>] <verb-phrase, 20-80 chars> | contact:<email>
-```
-
-For interactive end-users, a short natural-language summary is fine:
-
-```
-"reserve a Pixel 7 to run the checkout suite"
-```
+Every tool call requires a `userIntent` argument summarizing what the user is trying to accomplish — a natural-language sentence is sufficient (e.g., `"reserve a Pixel 7 to run the checkout suite"`). The plugin's audit logging consumes this.
 
 ## Cross-host install
 


### PR DESCRIPTION
## Summary

Post-cleanup pass on `AGENTS.md` so the cross-tool brief stays accurate for the non-Claude hosts that load it as live context (Gemini CLI, GitHub Copilot CLI, Cursor CLI).

## What changed

- **Tool surface corrected** — 28 tools across 5 categories (devices 4, apps 4, sessions 5, test-management 14, setup 1). The full Test Management suite (`saveTestCase`, test cases / runs / suites) + `getUserInputEvents` were missing from the count.
- **"Who reads this file" framing fixed** — only Gemini, Copilot, and Cursor consume `AGENTS.md` as agent context. Codex reads the mirrored `.codex/skills/*/SKILL.md`; Claude Code reads `skills/*/SKILL.md` directly.
- **Known-limitations bullets corrected** — `saveTestCase` exists, so the "no way to save a session as a test case" claim was wrong; `deleteSession` isn't a real tool name (it's `terminateSession`); dangling cross-reference to a non-existent SKILL.md section dropped.
- **Install matrix updated** — Gemini uses the full repo URL; Cursor and Codex install through the plugin marketplace per README; Claude Code row drops the `agents/` reference since that directory doesn't exist on `main` yet.
- **`run-interactive-test` coverage added** — new workflow section so non-Claude hosts know the second skill exists, per the CLAUDE.md "Cross-tool surface" note.
- **`userIntent format` reordered above the workflow sections** — agents reading top-to-bottom learn the calling convention before the first tool call.

## Validation

- `pnpm run validate` passes (all manifests in sync, mirror clean)
- `pnpm test` passes (53/53)
- DCO sign-off on the commit
- Pure documentation change, no code paths affected