### PR TITLE
chore(scripts): add version-sync to keep manifests in lockstep with package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "build:codex": "node scripts/sync-codex-artifacts.js",
     "build:tools": "node scripts/build-tool-definitions.js",
-    "build": "pnpm run build:tools && pnpm run build:codex",
-    "validate": "node scripts/validate.js && node scripts/sync-codex-artifacts.js --check",
+    "build:version": "node scripts/sync-version.js",
+    "build": "pnpm run build:tools && pnpm run build:codex && pnpm run build:version",
+    "validate": "node scripts/validate.js && node scripts/sync-codex-artifacts.js --check && node scripts/sync-version.js --check",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,119 @@
+// Keep the plugin version in lockstep across every host manifest, with package.json as the single source of truth.
+// This script derives the four manifest versions from package.json so there is exactly one number to bump.
+//
+// Source of truth: package.json `version`. Derived:
+//  - .claude-plugin/plugin.json        version
+//  - .codex/.codex-plugin/plugin.json  version
+//  - gemini-extension.json             version
+//  - .claude-plugin/marketplace.json   plugins[name=automate].version  (NOT metadata.version, which is the marketplace catalog version)
+// CHANGELOG.md is handwritten and never rewritten here; this script only checks that its top `## X.Y.Z` entry matches the source version.
+//
+// Run in:
+//  --write mode (default, used by `pnpm run build`) to propagate package.json's version into the manifests
+//  --check mode (used by validate / CI) to fail if any manifest or the CHANGELOG top entry drifts
+
+import {readFileSync, writeFileSync} from 'node:fs'
+import {join, resolve} from 'node:path'
+
+const SOURCE = 'package.json'
+
+// Manifests whose top-level `version` field tracks the source.
+const SIMPLE_TARGETS = [
+  '.claude-plugin/plugin.json',
+  '.codex/.codex-plugin/plugin.json',
+  'gemini-extension.json'
+]
+
+// marketplace.json carries the plugin version under plugins[name=automate].version.
+// Note: metadata.version must not be touched (it is the marketplace catalog version, not plugin version).
+const MARKETPLACE = '.claude-plugin/marketplace.json'
+const MARKETPLACE_PLUGIN = 'automate'
+
+const CHANGELOG = 'CHANGELOG.md'
+const FIX_HINT = 'Run `pnpm run build:version` to fix this'
+
+export function syncVersion(rootDir, {check = false} = {}) {
+  const errors = []
+  const warnings = []
+
+  const readJson = (rel) => JSON.parse(readFileSync(join(rootDir, rel), 'utf8'))
+  const writeJson = (rel, obj) => writeFileSync(join(rootDir, rel), JSON.stringify(obj, null, 2) + '\n')
+
+  const version = readJson(SOURCE).version
+  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+/.test(version)) {
+    errors.push(`${SOURCE} has an invalid version: ${JSON.stringify(version)}`)
+    return {errors, warnings, version}
+  }
+
+  for (const rel of SIMPLE_TARGETS) {
+    const obj = readJson(rel)
+    if (obj.version === version) {
+      continue
+    }
+
+    if (check) {
+      errors.push(`${rel} version is ${JSON.stringify(obj.version)}, expected ${version} (from ${SOURCE}). ${FIX_HINT}.`)
+    }
+    else {
+      obj.version = version
+      writeJson(rel, obj)
+    }
+  }
+
+  const market = readJson(MARKETPLACE)
+  const entry = Array.isArray(market.plugins) && market.plugins.find((p) => p.name === MARKETPLACE_PLUGIN)
+  if (!entry) {
+    errors.push(`${MARKETPLACE} has no plugins[] entry named "${MARKETPLACE_PLUGIN}"`)
+  }
+  else if (entry.version !== version) {
+    if (check) {
+      errors.push(`${MARKETPLACE} plugins["${MARKETPLACE_PLUGIN}"].version is ${JSON.stringify(entry.version)}, expected ${version}. ${FIX_HINT}.`)
+    }
+    else {
+      entry.version = version
+      writeJson(MARKETPLACE, market)
+    }
+  }
+
+  // CHANGELOG.md is handwritten; never rewritten. Its top `## X.Y.Z` entry must match the source.
+  // - Hard failure under --check (the CI gate)
+  // - Soft reminder under --write (the entry may not be written yet while a release is being prepared)
+  const changelog = readFileSync(join(rootDir, CHANGELOG), 'utf8')
+  const match = changelog.match(/^##\s+(\d+\.\d+\.\d+)\b/m)
+  if (!match) {
+    errors.push(`${CHANGELOG} has no \`## X.Y.Z\` entry`)
+  }
+  else if (match[1] !== version) {
+    const msg = `${CHANGELOG} top entry is ${match[1]}, but ${SOURCE} is ${version} — add a \`## ${version} - <YYYY-MM-DD>\` entry`
+    if (check) {
+      errors.push(msg)
+    }
+    else {
+      warnings.push(msg)
+    }
+  }
+
+  return {errors, warnings, version}
+}
+
+// CLI runner
+const isMainModule = import.meta.url === `file://${process.argv[1]}`
+if (isMainModule) {
+  const ROOT = resolve(import.meta.dirname, '..')
+  const check = process.argv.includes('--check')
+  const {errors, warnings, version} = syncVersion(ROOT, {check})
+
+  for (const msg of warnings) console.warn(`WARN: ${msg}`)
+
+  if (errors.length > 0) {
+    for (const msg of errors) console.error(`FAIL: ${msg}`)
+    process.exit(1)
+  }
+
+  if (check) {
+    console.log(`Plugin version ${version} is in sync across all manifests and CHANGELOG.md.`)
+  }
+  else {
+    console.log(`Synced plugin version ${version} → manifests (source of truth: ${SOURCE}).`)
+  }
+}

--- a/scripts/sync-version.test.js
+++ b/scripts/sync-version.test.js
@@ -1,0 +1,156 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest'
+import {mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync} from 'node:fs'
+import {join} from 'node:path'
+import {tmpdir} from 'node:os'
+import {syncVersion} from './sync-version.js'
+
+function writeJson(path, obj) {
+  writeFileSync(path, JSON.stringify(obj, null, 2) + '\n')
+}
+
+// Writes package.json + the four host manifests + CHANGELOG.md, all consistent at `version`.
+function setupFixture(root, version = '1.2.0') {
+  writeJson(join(root, 'package.json'), {name: 'automate', version, type: 'module'})
+
+  mkdirSync(join(root, '.claude-plugin'), {recursive: true})
+  writeJson(join(root, '.claude-plugin/plugin.json'), {name: 'automate', version})
+  writeJson(join(root, '.claude-plugin/marketplace.json'), {
+    name: 'kobiton',
+    metadata: {version: '1.0.0'},
+    plugins: [{name: 'automate', version}]
+  })
+
+  mkdirSync(join(root, '.codex/.codex-plugin'), {recursive: true})
+  writeJson(join(root, '.codex/.codex-plugin/plugin.json'), {name: 'automate', version})
+
+  writeJson(join(root, 'gemini-extension.json'), {name: 'kobiton-automate', version})
+
+  writeFileSync(join(root, 'CHANGELOG.md'), `# Changelog\n\n## ${version} - 2026-01-01\n\n- initial\n`)
+}
+
+const readJson = (root, rel) => JSON.parse(readFileSync(join(root, rel), 'utf8'))
+
+describe('syncVersion', () => {
+  let dir
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sync-version-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, {recursive: true, force: true})
+  })
+
+  describe('write mode', () => {
+    it('propagates package.json version into all four manifests', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, 'package.json'), {name: 'automate', version: '1.3.0', type: 'module'})
+
+      const {errors} = syncVersion(dir)
+      expect(errors).toEqual([])
+
+      expect(readJson(dir, '.claude-plugin/plugin.json').version).toBe('1.3.0')
+      expect(readJson(dir, '.codex/.codex-plugin/plugin.json').version).toBe('1.3.0')
+      expect(readJson(dir, 'gemini-extension.json').version).toBe('1.3.0')
+      expect(readJson(dir, '.claude-plugin/marketplace.json').plugins[0].version).toBe('1.3.0')
+    })
+
+    it('never touches marketplace metadata.version (the catalog version)', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, 'package.json'), {name: 'automate', version: '2.0.0', type: 'module'})
+
+      syncVersion(dir)
+
+      const market = readJson(dir, '.claude-plugin/marketplace.json')
+      expect(market.metadata.version).toBe('1.0.0')
+      expect(market.plugins[0].version).toBe('2.0.0')
+    })
+
+    it('is a no-op (no rewrite) when everything already matches', () => {
+      setupFixture(dir, '1.2.0')
+      const before = readFileSync(join(dir, '.claude-plugin/plugin.json'), 'utf8')
+
+      const {errors, warnings} = syncVersion(dir)
+      expect(errors).toEqual([])
+      expect(warnings).toEqual([])
+      expect(readFileSync(join(dir, '.claude-plugin/plugin.json'), 'utf8')).toBe(before)
+    })
+
+    it('warns (does not error) when CHANGELOG top entry lags, and still syncs manifests', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, 'package.json'), {name: 'automate', version: '1.3.0', type: 'module'})
+
+      const {errors, warnings} = syncVersion(dir)
+      expect(errors).toEqual([])
+      expect(warnings).toContainEqual(expect.stringContaining('CHANGELOG.md top entry is 1.2.0, but package.json is 1.3.0'))
+      expect(readJson(dir, 'gemini-extension.json').version).toBe('1.3.0')
+    })
+
+    it('errors when marketplace has no matching plugin entry', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, '.claude-plugin/marketplace.json'), {
+        name: 'kobiton',
+        metadata: {version: '1.0.0'},
+        plugins: [{name: 'something-else', version: '1.2.0'}]
+      })
+
+      const {errors} = syncVersion(dir)
+      expect(errors).toContainEqual(expect.stringContaining('no plugins[] entry named "automate"'))
+    })
+  })
+
+  describe('check mode', () => {
+    it('passes when all manifests and the CHANGELOG match', () => {
+      setupFixture(dir, '1.2.0')
+      const {errors, warnings} = syncVersion(dir, {check: true})
+      expect(errors).toEqual([])
+      expect(warnings).toEqual([])
+    })
+
+    it('fails when a top-level manifest version drifts', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, 'gemini-extension.json'), {name: 'kobiton-automate', version: '1.1.9'})
+
+      const {errors} = syncVersion(dir, {check: true})
+      expect(errors).toContainEqual(expect.stringContaining('gemini-extension.json version is "1.1.9", expected 1.2.0'))
+    })
+
+    it('fails when the marketplace plugin entry drifts', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, '.claude-plugin/marketplace.json'), {
+        name: 'kobiton',
+        metadata: {version: '1.0.0'},
+        plugins: [{name: 'automate', version: '1.1.0'}]
+      })
+
+      const {errors} = syncVersion(dir, {check: true})
+      expect(errors).toContainEqual(expect.stringContaining('plugins["automate"].version is "1.1.0", expected 1.2.0'))
+    })
+
+    it('fails when the CHANGELOG top entry does not match', () => {
+      setupFixture(dir, '1.2.0')
+      writeFileSync(join(dir, 'CHANGELOG.md'), '# Changelog\n\n## 1.1.0 - 2026-01-01\n\n- old\n')
+
+      const {errors} = syncVersion(dir, {check: true})
+      expect(errors).toContainEqual(expect.stringContaining('CHANGELOG.md top entry is 1.1.0, but package.json is 1.2.0'))
+    })
+
+    it('ignores a differing marketplace metadata.version', () => {
+      setupFixture(dir, '1.2.0')
+      const market = readJson(dir, '.claude-plugin/marketplace.json')
+      market.metadata.version = '9.9.9'
+      writeJson(join(dir, '.claude-plugin/marketplace.json'), market)
+
+      const {errors} = syncVersion(dir, {check: true})
+      expect(errors).toEqual([])
+    })
+
+    it('errors on an invalid package.json version', () => {
+      setupFixture(dir, '1.2.0')
+      writeJson(join(dir, 'package.json'), {name: 'automate', version: 'not-a-version', type: 'module'})
+
+      const {errors} = syncVersion(dir, {check: true})
+      expect(errors).toContainEqual(expect.stringContaining('package.json has an invalid version'))
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds `scripts/sync-version.js`. `package.json`.`version` becomes the **single source of truth** for the plugin version. It propagates that version into the four host manifests, and a `--check` mode fails if any manifest, or the top `CHANGELOG.md` entry, drifts from it:
- `.claude-plugin/plugin.json`
- `.codex/.codex-plugin/plugin.json`
- `gemini-extension.json`
- `.claude-plugin/marketplace.json`.`plugins[].version`.

Command:
- `pnpm run build:version`: write mode (also bundled into `pnpm run build`)
- `pnpm run validate`: now also runs `sync-version.js --check` (the CI gate)


## ⚠️ Note about merge order 

This PR carries **only the tooling, no version bump**. The check will be **red against the current `main`**, because `main` is already inconsistent (CHANGELOG + `plugin.json` at 1.2.1, the other manifests + `package.json` at 1.2.0).

Intended sequence:
1. Merge #84 first -> `main` becomes consistent at **1.2.2**.
2. Rebase this branch onto the updated `main`.
3. The check goes green -> ready to mark "Ready for review" and merge.

## Out of scope (future)

End-to-end release automation with release-please (conventional-commit-driven Release PR that bumps the version and regenerates the CHANGELOG). `sync-version.js` is the foundation it would build on.
