### PR TITLE
feat: add Cursor CLI support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "automate",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
       "author": {
         "name": "Kobiton Inc.",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.codex/.codex-plugin/plugin.json
+++ b/.codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.codex/skills/run-automation-suite/SKILL.md
+++ b/.codex/skills/run-automation-suite/SKILL.md
@@ -50,7 +50,7 @@ This skill calls tools served by the Kobiton MCP server at `api.kobiton.com/mcp`
 | `.mcp.json` (default) | OAuth 2.1 browser flow | Interactive AI-CLI session for an end user |
 | `.mcp.apikey-example.json` | Basic auth header — `Authorization: Basic base64(username:apikey)` from the `KOBITON_AUTH` env var | CI / headless / scripted invocations; copy this file over `.mcp.json` |
 
-If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate the Kobiton MCP server in their AI CLI before any device or session call can succeed. The exact invocation depends on the host (e.g. `/mcp` in Claude Code, `/mcp auth kobiton` in GitHub Copilot CLI and Gemini CLI, automatic browser flow on first tool call in Codex CLI — see the plugin README for current per-CLI commands). Do NOT attempt to recover by retrying — the auth context is fixed at session start.
+If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate the Kobiton MCP server in their AI CLI before any device or session call can succeed. The exact invocation depends on the host (e.g. `/mcp` in Claude Code, `/mcp auth kobiton` in GitHub Copilot CLI and Gemini CLI, automatic browser flow on first tool call in Codex CLI, `/mcp list` then Login in Cursor CLI — see the plugin README for current per-CLI commands). Do NOT attempt to recover by retrying — the auth context is fixed at session start.
 
 ## Instructions
 

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,13 +5,38 @@
     "email": "support@kobiton.com"
   },
   "metadata": {
-    "description": "Kobiton mobile testing platform plugins for AI coding assistants"
+    "description": "Kobiton mobile testing platform plugins for AI coding assistants",
+    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "automate",
-      "source": "./",
-      "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results"
+      "version": "1.3.0",
+      "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
+      "author": {
+        "name": "Kobiton Inc.",
+        "email": "support@kobiton.com"
+      },
+      "license": "MIT",
+      "category": "developer-tools",
+      "keywords": [
+        "mobile",
+        "test",
+        "automation",
+        "appium",
+        "mcp",
+        "devices",
+        "kobiton"
+      ],
+      "tags": [
+        "mobile",
+        "testing",
+        "appium",
+        "automation",
+        "devices",
+        "kobiton"
+      ],
+      "source": "./"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "kobiton",
+  "owner": {
+    "name": "Kobiton Inc.",
+    "email": "support@kobiton.com"
+  },
+  "metadata": {
+    "description": "Kobiton mobile testing platform plugins for AI coding assistants"
+  },
+  "plugins": [
+    {
+      "name": "automate",
+      "source": "./",
+      "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results"
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "automate",
   "displayName": "Kobiton Automate",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "automate",
+  "displayName": "Kobiton Automate",
+  "version": "1.2.2",
+  "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
+  "author": {
+    "name": "Kobiton Inc.",
+    "email": "support@kobiton.com"
+  },
+  "homepage": "https://kobiton.com",
+  "repository": "https://github.com/kobiton/automate",
+  "license": "MIT",
+  "keywords": [
+    "mobile",
+    "test",
+    "automation",
+    "appium",
+    "mcp",
+    "devices",
+    "kobiton"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "mobile",
+    "testing",
+    "appium",
+    "automation",
+    "devices",
+    "kobiton"
+  ],
+  "skills": "./skills/",
+  "hooks": "./.cursor/hooks/hooks.json",
+  "mcpServers": "./.cursor/mcp.json"
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "displayName": "Kobiton Automate",
+  "displayName": "automate",
   "version": "1.3.0",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
@@ -28,6 +28,7 @@
     "devices",
     "kobiton"
   ],
+  "commands": "./commands/",
   "skills": "./skills/",
   "hooks": "./.cursor/hooks/hooks.json",
   "mcpServers": "./.cursor/mcp.json"

--- a/.cursor/hooks/hooks.json
+++ b/.cursor/hooks/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "bash ${CURSOR_PLUGIN_ROOT}/scripts/install-cli.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/mcp.apikey-example.json
+++ b/.cursor/mcp.apikey-example.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "API key auth for CI/headless environments. Copy to .cursor/mcp.json and set KOBITON_AUTH env var (format: 'Basic <base64(username:apiKey)>'). Cursor expands ${env:NAME} at startup.",
+  "mcpServers": {
+    "kobiton": {
+      "url": "https://api.kobiton.com/mcp",
+      "headers": {
+        "Authorization": "${env:KOBITON_AUTH}",
+        "X-AI-Tool-Name": "Cursor"
+      }
+    }
+  }
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,10 @@
 {
   "mcpServers": {
     "kobiton": {
-      "url": "https://api.kobiton.com/mcp"
+      "url": "https://api.kobiton.com/mcp",
+      "headers": {
+        "X-AI-Tool-Name": "Cursor"
+      }
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Desktop.ini
 .cursor/*
 !.cursor/mcp.json
 !.cursor/mcp.apikey-example.json
+!.cursor/hooks
 .history
 
 # Vim/Emacs

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Desktop.ini
 .vscode
 .cursor/*
 !.cursor/mcp.json
+!.cursor/mcp.apikey-example.json
 .history
 
 # Vim/Emacs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## 1.3.0 - 2026-05-28
 
 - Multi-CLI support extended: install on [Cursor CLI](https://cursor.com/cli) in addition to the existing four hosts (Claude Code, GitHub Copilot CLI, Gemini CLI, Codex CLI)
-- New `.cursor-plugin/plugin.json` + `.cursor-plugin/marketplace.json` following the [cursor/plugins](https://github.com/cursor/plugins) convention — clone into `~/.cursor/plugins/` for the full plugin (skills, hooks, MCP), or drop just `.cursor/mcp.json` into any project for an MCP-only setup
-- New `.cursor/hooks/hooks.json` with a `sessionStart` event that auto-installs the `~/.kobiton/bin/kobiton` CLI wrapper, giving Cursor parity with the SessionStart hook on Claude Code and Codex CLI
+- New `.cursor-plugin/plugin.json` + `.cursor-plugin/marketplace.json` following the [cursor/plugins](https://github.com/cursor/plugins) convention — install in-session with `/plugin marketplace add https://github.com/kobiton/automate`, or drop just `.cursor/mcp.json` into any project for an MCP-only setup
+- New `.cursor/hooks/hooks.json` declaring a `sessionStart` event for the `~/.kobiton/bin/kobiton` CLI wrapper; Cursor CLI does not currently run plugin sessionStart hooks, so run `/automate:setup` once after install to create the wrapper (same as Copilot and Gemini)
 - MCP requests originating from Cursor carry `X-AI-Tool-Name: Cursor` for adoption analytics (KOB-52724)
 - Documented install paths for additional generic MCP clients — ChatGPT (Apps SDK) and Continue / Cline / other Streamable-HTTP clients — in a new "Other MCP Clients" README subsection (configs derived from each client's published documentation; not yet end-to-end validated)
+- `/automate:setup` and `/automate:doctor` are now wired for Cursor CLI too — the `.cursor-plugin/plugin.json` `commands` field points at the shared `commands/*.md` set, which Cursor reads in the same Markdown + YAML-frontmatter format
 
 
 ## 1.2.2 - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+## 1.3.0 - 2026-05-28
 
-- Documented cross-client install paths for Cursor, ChatGPT (Apps SDK), and Continue / Cline / other generic MCP clients in README — adds an "Other MCP Clients" subsection under Installation. Ships a default `.cursor/mcp.json` at the repo root so Cursor users get a working config without hand-crafting one. Honest framing: configs derived from each client's published documentation; end-to-end-tested only on the four already-documented clients
+- Multi-CLI support extended: install on [Cursor CLI](https://cursor.com/cli) in addition to the existing four hosts (Claude Code, GitHub Copilot CLI, Gemini CLI, Codex CLI)
+- New `.cursor-plugin/plugin.json` + `.cursor-plugin/marketplace.json` following the [cursor/plugins](https://github.com/cursor/plugins) convention — clone into `~/.cursor/plugins/` for the full plugin (skills, hooks, MCP), or drop just `.cursor/mcp.json` into any project for an MCP-only setup
+- New `.cursor/hooks/hooks.json` with a `sessionStart` event that auto-installs the `~/.kobiton/bin/kobiton` CLI wrapper, giving Cursor parity with the SessionStart hook on Claude Code and Codex CLI
+- MCP requests originating from Cursor carry `X-AI-Tool-Name: Cursor` for adoption analytics (KOB-52724)
+- Documented install paths for additional generic MCP clients — ChatGPT (Apps SDK) and Continue / Cline / other Streamable-HTTP clients — in a new "Other MCP Clients" README subsection (configs derived from each client's published documentation; not yet end-to-end validated)
 
 
 ## 1.2.2 - 2026-05-25

--- a/README.md
+++ b/README.md
@@ -127,38 +127,41 @@ Launch `codex` and run `/mcp` to confirm. The OAuth flow still applies on the fi
 
 ### Cursor CLI
 
-Install Cursor CLI if you don't have it yet:
-
-```bash
-curl https://cursor.com/install -fsSL | bash
-```
-
-Clone the Kobiton plugin into your project (the same `.cursor/mcp.json` then auto-registers the Kobiton MCP server):
-
-```bash
-cd my-project
-git clone https://github.com/kobiton/automate.git .kobiton-automate
-cp -r .kobiton-automate/.cursor .
-cursor-agent
-```
-
-Inside the session, run `/mcp` to confirm `kobiton` is connected. The first connection opens a browser for Kobiton OAuth login.
-
-<details>
-<summary><strong>Alternative: install as a full Cursor plugin (skills, hooks, marketplace metadata)</strong></summary>
-
-To pick up the bundled skills and the sessionStart hook that installs `~/.kobiton/bin/kobiton` automatically, clone into Cursor's plugins directory instead:
+Clone the Kobiton plugin into Cursor's global plugin directory:
 
 ```bash
 git clone https://github.com/kobiton/automate.git ~/.cursor/plugins/kobiton-automate
 ```
 
-Restart Cursor (`cursor-agent` or the IDE) so the new plugin is discovered. The plugin's `.cursor-plugin/plugin.json` registers the MCP server, skills, and hooks in one shot — no need to copy `.cursor/mcp.json` separately.
+Then start a Cursor CLI session from your project:
+
+```bash
+cd my-project
+agent
+```
+
+The plugin's `.cursor-plugin/plugin.json` registers the `kobiton` MCP server, bundled skills, and a `sessionStart` hook that auto-installs `~/.kobiton/bin/kobiton`. Run `/mcp` inside the session to confirm `kobiton` is connected — the first call opens a browser for Kobiton OAuth login.
+
+<details>
+<summary><strong>Alternative: project-only MCP config (no global install)</strong></summary>
+
+For a lightweight per-project setup that skips the bundled skills and the sessionStart hook, just drop `.cursor/mcp.json` from this repo into your project's `.cursor/` directory:
+
+```bash
+cd my-project
+mkdir -p .cursor
+curl -sLO --output-dir .cursor https://raw.githubusercontent.com/kobiton/automate/main/.cursor/mcp.json
+agent
+```
+
+You won't get the bundled skills or auto CLI-wrapper install — run `/automate:setup`-equivalent flows manually if needed.
 </details>
 
 ### Other MCP Clients
 
-The Kobiton MCP server (`https://api.kobiton.com/mcp`) speaks the open Model Context Protocol and can be consumed by any spec-compliant MCP client. The configs below are derived from each client's published documentation; the Kobiton-side OAuth flow is the same across all of them. **End-to-end tested only on Claude Code, Copilot CLI, Gemini CLI, Codex CLI, and Cursor CLI**; entries below are configs we expect to work but have not yet validated — please open an issue if any do not work for your setup.
+Kobiton's MCP server is built on the open [Model Context Protocol](https://modelcontextprotocol.io), so **any MCP-compatible client can connect to it**. Same endpoint (`https://api.kobiton.com/mcp`), same browser-based OAuth login as the clients above.
+
+> **Good to know:** End-to-end tested only on Claude Code, Copilot CLI, Gemini CLI, Codex CLI, and Cursor CLI; entries below are configs we expect to work but have not yet validated. Please [open an issue](https://github.com/kobiton/automate/issues/new?template=bug_report.md) if any do not work for your setup. We're happy to help.
 
 #### ChatGPT (Apps SDK)
 
@@ -170,9 +173,9 @@ https://api.kobiton.com/mcp
 
 The Apps SDK does not require a separate manifest file; tool descriptors, OAuth flow, and `_meta.ui` widget hints flow through the MCP protocol itself. Reference: [developers.openai.com/apps-sdk/build/mcp-server](https://developers.openai.com/apps-sdk/build/mcp-server).
 
-#### Continue / Cline / other generic MCP clients
+#### Cursor / Continue / Cline / other generic MCP clients
 
-Most generic MCP clients support the open Streamable HTTP transport. Use a config block like:
+The Cursor IDE (the desktop editor, not the `agent` CLI covered above) reads MCP servers from the `.cursor/mcp.json` this repo already ships, so opening the project is enough.
 
 ```json
 {
@@ -184,7 +187,7 @@ Most generic MCP clients support the open Streamable HTTP transport. Use a confi
 }
 ```
 
-Adjust to your client's specific format. The server URL and OAuth handshake are the same; if your client doesn't support OAuth, fall back to the API-key auth path (see [API Key Authentication](#api-key-authentication-alternative) below) — most clients accept custom `headers` blocks.
+Adjust to your client's specific format. The server URL and OAuth handshake are the same; if your client doesn't support OAuth, fall back to the API-key auth path (see [API Key Authentication](#api-key-authentication-alternative) below) - most clients accept custom `headers` blocks.
 
 ## Login
 
@@ -361,7 +364,7 @@ After the plugin is updated upstream, pull the latest version:
 - **Claude Code / Copilot CLI:** run `/plugin install automate@kobiton` again
 - **Gemini CLI:** run `gemini extensions update kobiton-automate` from your shell
 - **Codex CLI:** run `codex plugin marketplace upgrade` to refresh the marketplace catalog, then reinstall the plugin from the browser to pull the latest manifest
-- **Cursor CLI:** `cd` into your clone (`~/.cursor/plugins/kobiton-automate` or `.kobiton-automate` inside your project) and run `git pull`. Restart `cursor-agent` so the new manifest is picked up.
+- **Cursor CLI:** `cd` into your clone (`~/.cursor/plugins/kobiton-automate` or `.kobiton-automate` inside your project) and run `git pull`. Restart `agent` so the new manifest is picked up.
 
 To make sure the assistant picks up the changes with no stale cache, reload per CLI:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Cloud](https://img.shields.io/badge/Cloud-☁️-blue)](https://kobiton.com)
 [![Twitter Follow](https://img.shields.io/twitter/follow/KobitonMobile?style=social)](https://x.com/KobitonMobile)
 
-Plugin for the [Kobiton](https://kobiton.com) mobile testing platform. Works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and [Codex CLI](https://github.com/openai/codex). Manage devices, upload apps, run automation sessions, and view test results directly from your AI coding assistant.
+Plugin for the [Kobiton](https://kobiton.com) mobile testing platform. Works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex CLI](https://github.com/openai/codex), and [Cursor CLI](https://cursor.com/cli). Manage devices, upload apps, run automation sessions, and view test results directly from your AI coding assistant.
 
 ## Contents
 
@@ -14,6 +14,8 @@ Plugin for the [Kobiton](https://kobiton.com) mobile testing platform. Works wit
   - [GitHub Copilot CLI](#github-copilot-cli)
   - [Gemini CLI](#gemini-cli)
   - [Codex CLI](#codex-cli)
+  - [Cursor CLI](#cursor-cli)
+  - [Other MCP Clients](#other-mcp-clients)
 - [Login](#login)
   - [API Key Authentication (Alternative)](#api-key-authentication-alternative)
 - [Getting Started](#getting-started)
@@ -34,7 +36,7 @@ Plugin for the [Kobiton](https://kobiton.com) mobile testing platform. Works wit
 Make sure you have:
 
 - **A Kobiton account** - sign up at [kobiton.com](https://kobiton.com) if you don't have one
-- **A supported AI CLI** - install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or [Codex CLI](https://github.com/openai/codex)
+- **A supported AI CLI** - install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex CLI](https://github.com/openai/codex), or [Cursor CLI](https://cursor.com/cli)
 - **A project directory** - your AI assistant must launch from a workspace, not from your home folder
 
 ## Installation
@@ -123,25 +125,40 @@ curl -sLO https://raw.githubusercontent.com/kobiton/automate/main/AGENTS.md
 Launch `codex` and run `/mcp` to confirm. The OAuth flow still applies on the first tool call.
 </details>
 
-### Other MCP Clients
+### Cursor CLI
 
-The Kobiton MCP server (`https://api.kobiton.com/mcp`) speaks the open Model Context Protocol and can be consumed by any spec-compliant MCP client. The configs below are derived from each client's published documentation; the Kobiton-side OAuth flow is the same across all of them. **End-to-end tested only on Claude Code, Copilot CLI, Gemini CLI, and Codex CLI**; entries below are configs we expect to work but have not yet validated — please open an issue if any do not work for your setup.
+Install Cursor CLI if you don't have it yet:
 
-#### Cursor
-
-Cursor reads MCP servers from `.cursor/mcp.json` at the project root (or `~/.cursor/mcp.json` for global). This repo ships a default project-level config at [`.cursor/mcp.json`](.cursor/mcp.json):
-
-```json
-{
-  "mcpServers": {
-    "kobiton": {
-      "url": "https://api.kobiton.com/mcp"
-    }
-  }
-}
+```bash
+curl https://cursor.com/install -fsSL | bash
 ```
 
-On first connection Cursor opens a browser for OAuth login (same flow as Claude Code's `/mcp` command). Cursor's fixed OAuth redirect URL is `cursor://anysphere.cursor-mcp/oauth/callback`. Reference: [cursor.com/docs/context/mcp](https://cursor.com/docs/context/mcp).
+Clone the Kobiton plugin into your project (the same `.cursor/mcp.json` then auto-registers the Kobiton MCP server):
+
+```bash
+cd my-project
+git clone https://github.com/kobiton/automate.git .kobiton-automate
+cp -r .kobiton-automate/.cursor .
+cursor-agent
+```
+
+Inside the session, run `/mcp` to confirm `kobiton` is connected. The first connection opens a browser for Kobiton OAuth login.
+
+<details>
+<summary><strong>Alternative: install as a full Cursor plugin (skills, hooks, marketplace metadata)</strong></summary>
+
+To pick up the bundled skills and the sessionStart hook that installs `~/.kobiton/bin/kobiton` automatically, clone into Cursor's plugins directory instead:
+
+```bash
+git clone https://github.com/kobiton/automate.git ~/.cursor/plugins/kobiton-automate
+```
+
+Restart Cursor (`cursor-agent` or the IDE) so the new plugin is discovered. The plugin's `.cursor-plugin/plugin.json` registers the MCP server, skills, and hooks in one shot — no need to copy `.cursor/mcp.json` separately.
+</details>
+
+### Other MCP Clients
+
+The Kobiton MCP server (`https://api.kobiton.com/mcp`) speaks the open Model Context Protocol and can be consumed by any spec-compliant MCP client. The configs below are derived from each client's published documentation; the Kobiton-side OAuth flow is the same across all of them. **End-to-end tested only on Claude Code, Copilot CLI, Gemini CLI, Codex CLI, and Cursor CLI**; entries below are configs we expect to work but have not yet validated — please open an issue if any do not work for your setup.
 
 #### ChatGPT (Apps SDK)
 
@@ -179,6 +196,7 @@ You can also trigger or inspect authentication explicitly:
 - **GitHub Copilot CLI**: type `/mcp auth kobiton` to start the OAuth flow; use `/mcp` (or `/mcp show`) to inspect server status
 - **Gemini CLI**: type `/mcp auth kobiton` to start the OAuth flow; use `/mcp` to inspect server status
 - **Codex CLI**: browser opens automatically on the first MCP tool call (e.g. *"List my Kobiton devices"*) after plugin install. Tokens are cached in the OS keychain with automatic refresh. Use `/mcp` (or `/mcp verbose`) to inspect server status
+- **Cursor CLI**: type `/mcp` and select **kobiton** to start the OAuth flow; tokens are stored by Cursor in the OS keychain
 
 Behind the scenes, `.mcp.json` points to the Kobiton MCP server and authentication uses OAuth 2.1:
 
@@ -246,7 +264,7 @@ To verify everything is wired correctly, run the diagnostic:
 
 **CLI symlink install behavior across CLIs:** The `run-interactive-test` skill depends on a `~/.kobiton/bin/kobiton` symlink.
 
-- **Claude Code, Codex CLI**: is recreated automatically by a bundled SessionStart hook on every session start. On Codex, the first session prompts you to trust the hook once via `/hooks`; subsequent sessions run it silently. Running `/automate:setup` (Claude) also recreates the symlink on demand.
+- **Claude Code, Codex CLI, Cursor CLI**: is recreated automatically by a bundled SessionStart hook on every session start. On Codex, the first session prompts you to trust the hook once via `/hooks`; subsequent sessions run it silently. Cursor uses the same mechanism via `.cursor/hooks/hooks.json` (the `sessionStart` event). Running `/automate:setup` (Claude) also recreates the symlink on demand.
 - **GitHub Copilot CLI, Gemini CLI**: both CLIs load `/automate:setup` (Copilot reads Claude-format Markdown commands; Gemini reads bundled TOML commands at `commands/automate/setup.toml`). Run `/automate:setup` once after install to create the symlink. Neither CLI has a SessionStart hook, so the symlink isn't recreated automatically - re-run setup if it goes missing.
 
 Manual fallback - if the SessionStart hook was denied on Codex, or you need to install without an active session:
@@ -343,6 +361,7 @@ After the plugin is updated upstream, pull the latest version:
 - **Claude Code / Copilot CLI:** run `/plugin install automate@kobiton` again
 - **Gemini CLI:** run `gemini extensions update kobiton-automate` from your shell
 - **Codex CLI:** run `codex plugin marketplace upgrade` to refresh the marketplace catalog, then reinstall the plugin from the browser to pull the latest manifest
+- **Cursor CLI:** `cd` into your clone (`~/.cursor/plugins/kobiton-automate` or `.kobiton-automate` inside your project) and run `git pull`. Restart `cursor-agent` so the new manifest is picked up.
 
 To make sure the assistant picks up the changes with no stale cache, reload per CLI:
 

--- a/README.md
+++ b/README.md
@@ -127,35 +127,24 @@ Launch `codex` and run `/mcp` to confirm. The OAuth flow still applies on the fi
 
 ### Cursor CLI
 
-Clone the Kobiton plugin into Cursor's global plugin directory:
-
-```bash
-git clone https://github.com/kobiton/automate.git ~/.cursor/plugins/kobiton-automate
-```
-
-Then start a Cursor CLI session from your project:
+Open your project and start a Cursor CLI session:
 
 ```bash
 cd my-project
 agent
 ```
 
-The plugin's `.cursor-plugin/plugin.json` registers the `kobiton` MCP server, bundled skills, and a `sessionStart` hook that auto-installs `~/.kobiton/bin/kobiton`. Run `/mcp` inside the session to confirm `kobiton` is connected — the first call opens a browser for Kobiton OAuth login.
+Inside the session, add the Kobiton marketplace and fetch the **automate** plugin from the repo.
 
-<details>
-<summary><strong>Alternative: project-only MCP config (no global install)</strong></summary>
-
-For a lightweight per-project setup that skips the bundled skills and the sessionStart hook, just drop `.cursor/mcp.json` from this repo into your project's `.cursor/` directory:
-
-```bash
-cd my-project
-mkdir -p .cursor
-curl -sLO --output-dir .cursor https://raw.githubusercontent.com/kobiton/automate/main/.cursor/mcp.json
-agent
+```
+/plugin marketplace add https://github.com/kobiton/automate
 ```
 
-You won't get the bundled skills or auto CLI-wrapper install — run `/automate:setup`-equivalent flows manually if needed.
-</details>
+Then open **automate** and choose **Install for you**, it installs the 2 skills, the `kobiton` MCP server, and the `/automate:setup` and `/automate:doctor` commands.
+
+Run `/mcp list`, select **kobiton**, and choose **Login** to complete Kobiton OAuth in the browser.
+
+Run `/automate:setup` once to install the `~/.kobiton/bin/kobiton` CLI wrapper used by the `run-interactive-test` skill.
 
 ### Other MCP Clients
 
@@ -189,6 +178,21 @@ The Cursor IDE (the desktop editor, not the `agent` CLI covered above) reads MCP
 
 Adjust to your client's specific format. The server URL and OAuth handshake are the same; if your client doesn't support OAuth, fall back to the API-key auth path (see [API Key Authentication](#api-key-authentication-alternative) below) - most clients accept custom `headers` blocks.
 
+<details>
+<summary><strong>Alternative: project-only MCP config (MCP server only, no skills or commands)</strong></summary>
+
+For a lightweight per-project setup that registers just the `kobiton` MCP server, drop `.cursor/mcp.json` from this repo into your project's `.cursor/` directory:
+
+```bash
+cd my-project
+mkdir -p .cursor
+curl -sLO --output-dir .cursor https://raw.githubusercontent.com/kobiton/automate/main/.cursor/mcp.json
+agent
+```
+
+You won't get the bundled skills, the `/automate:setup` and `/automate:doctor` commands, or the CLI wrapper.
+</details>
+
 ## Login
 
 The first time your AI assistant calls a Kobiton tool, a browser window opens for OAuth login. Sign in with your Kobiton credentials, tokens are then managed automatically by the assistant.
@@ -199,7 +203,7 @@ You can also trigger or inspect authentication explicitly:
 - **GitHub Copilot CLI**: type `/mcp auth kobiton` to start the OAuth flow; use `/mcp` (or `/mcp show`) to inspect server status
 - **Gemini CLI**: type `/mcp auth kobiton` to start the OAuth flow; use `/mcp` to inspect server status
 - **Codex CLI**: browser opens automatically on the first MCP tool call (e.g. *"List my Kobiton devices"*) after plugin install. Tokens are cached in the OS keychain with automatic refresh. Use `/mcp` (or `/mcp verbose`) to inspect server status
-- **Cursor CLI**: type `/mcp` and select **kobiton** to start the OAuth flow; tokens are stored by Cursor in the OS keychain
+- **Cursor CLI**: run `/mcp list`, select **kobiton**, and choose **Login** to start the OAuth flow; tokens are stored by Cursor in the OS keychain
 
 Behind the scenes, `.mcp.json` points to the Kobiton MCP server and authentication uses OAuth 2.1:
 
@@ -267,8 +271,8 @@ To verify everything is wired correctly, run the diagnostic:
 
 **CLI symlink install behavior across CLIs:** The `run-interactive-test` skill depends on a `~/.kobiton/bin/kobiton` symlink.
 
-- **Claude Code, Codex CLI, Cursor CLI**: is recreated automatically by a bundled SessionStart hook on every session start. On Codex, the first session prompts you to trust the hook once via `/hooks`; subsequent sessions run it silently. Cursor uses the same mechanism via `.cursor/hooks/hooks.json` (the `sessionStart` event). Running `/automate:setup` (Claude) also recreates the symlink on demand.
-- **GitHub Copilot CLI, Gemini CLI**: both CLIs load `/automate:setup` (Copilot reads Claude-format Markdown commands; Gemini reads bundled TOML commands at `commands/automate/setup.toml`). Run `/automate:setup` once after install to create the symlink. Neither CLI has a SessionStart hook, so the symlink isn't recreated automatically - re-run setup if it goes missing.
+- **Claude Code, Codex CLI**: recreated automatically by a bundled SessionStart hook on every session start. On Codex, the first session prompts you to trust the hook once via `/hooks`; subsequent sessions run it silently. Running `/automate:setup` also recreates the symlink on demand.
+- **GitHub Copilot CLI, Gemini CLI, Cursor CLI**: no SessionStart hook runs, so create the symlink manually by running the setup command once after install: `/automate:setup` on Copilot, Gemini and Cursor (Copilot reads Claude-format Markdown commands; Gemini reads bundled TOML at `commands/automate/setup.toml`). Re-run it if the symlink goes missing.
 
 Manual fallback - if the SessionStart hook was denied on Codex, or you need to install without an active session:
 
@@ -364,7 +368,7 @@ After the plugin is updated upstream, pull the latest version:
 - **Claude Code / Copilot CLI:** run `/plugin install automate@kobiton` again
 - **Gemini CLI:** run `gemini extensions update kobiton-automate` from your shell
 - **Codex CLI:** run `codex plugin marketplace upgrade` to refresh the marketplace catalog, then reinstall the plugin from the browser to pull the latest manifest
-- **Cursor CLI:** `cd` into your clone (`~/.cursor/plugins/kobiton-automate` or `.kobiton-automate` inside your project) and run `git pull`. Restart `agent` so the new manifest is picked up.
+- **Cursor CLI:** re-run `/plugin marketplace add https://github.com/kobiton/automate` and reinstall the **automate** plugin - Cursor CLI has no dedicated update command yet (`/plugin marketplace list` only lists what's installed). Restart `agent` so the new manifest is picked up.
 
 To make sure the assistant picks up the changes with no stale cache, reload per CLI:
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,4 +1,5 @@
 ---
+name: "automate:doctor"
 description: Run read-only health checks on the Kobiton automate plugin (CLI, credentials, profile).
 allowed-tools:
   - Bash

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-name: automate-doctor
+name: "automate:doctor"
 description: Run read-only health checks on the Kobiton automate plugin (CLI, credentials, profile).
 allowed-tools:
   - Bash

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,5 +1,5 @@
 ---
-name: "automate:doctor"
+name: automate-doctor
 description: Run read-only health checks on the Kobiton automate plugin (CLI, credentials, profile).
 allowed-tools:
   - Bash

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,4 +1,5 @@
 ---
+name: "automate:setup"
 description: Fetch Kobiton credentials from the authenticated MCP server and write them to ~/.kobiton/.credentials.
 allowed-tools:
   - Bash
@@ -11,7 +12,7 @@ Bootstrap the plugin: ensure the CLI wrapper symlink is installed, then fetch th
 
 ## Step 0: Ensure the CLI wrapper symlink is installed
 
-The `run-interactive-test` skill depends on `~/.kobiton/bin/kobiton`. Claude Code and Codex CLI both recreate this symlink automatically via a bundled SessionStart hook; on Codex, the user trusts the hook once via `/hooks` after install. This command (`/automate:setup`) re-installs the symlink on demand. GitHub Copilot CLI and Gemini CLI also load `/automate:setup` (Copilot via Claude-format `.md`, Gemini via the bundled TOML at `commands/automate/setup.toml`) — neither has a SessionStart hook, so users on those CLIs run `/automate:setup` once after install.
+The `run-interactive-test` skill depends on `~/.kobiton/bin/kobiton`. Claude Code and Codex CLI both recreate this symlink automatically via a bundled SessionStart hook; on Codex, the user trusts the hook once via `/hooks` after install. This command (`/automate:setup`) re-installs the symlink on demand. GitHub Copilot CLI and Gemini CLI also load `/automate:setup` (Copilot via Claude-format `.md`, Gemini via the bundled TOML at `commands/automate/setup.toml`) — neither has a SessionStart hook, so users on those CLIs run `/automate:setup` once after install. Cursor CLI loads this same `.md` via the `commands` field in `.cursor-plugin/plugin.json` and recreates the symlink through its own `sessionStart` hook.
 
 Run the install script bundled with this plugin. This file (`setup.md`) lives at `<plugin-root>/commands/setup.md`, so the install script is at `<plugin-root>/scripts/install-cli.sh`. Resolve `<plugin-root>` to its absolute path and run:
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-name: "automate:setup"
+name: automate-setup
 description: Fetch Kobiton credentials from the authenticated MCP server and write them to ~/.kobiton/.credentials.
 allowed-tools:
   - Bash

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-name: automate-setup
+name: "automate:setup"
 description: Fetch Kobiton credentials from the authenticated MCP server and write them to ~/.kobiton/.credentials.
 allowed-tools:
   - Bash

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kobiton-automate",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "type": "module",
   "private": true,
   "description": "Kobiton plugin manifests, tool schemas, and skills for AI coding assistants",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -7,6 +7,7 @@
 //  - .cursor-plugin/plugin.json        version
 //  - gemini-extension.json             version
 //  - .claude-plugin/marketplace.json   plugins[name=automate].version  (NOT metadata.version, which is the marketplace catalog version)
+//  - .cursor-plugin/marketplace.json   plugins[name=automate].version  (NOT metadata.version, same convention as Claude marketplace)
 // CHANGELOG.md is handwritten and never rewritten here; this script only checks that its top `## X.Y.Z` entry matches the source version.
 //
 // Run in:
@@ -26,10 +27,12 @@ const SIMPLE_TARGETS = [
   'gemini-extension.json'
 ]
 
-// marketplace.json carries the plugin version under plugins[name=automate].version.
+// Marketplace manifests carry the plugin version under plugins[name=automate].version.
 // Note: metadata.version must not be touched (it is the marketplace catalog version, not plugin version).
-const MARKETPLACE = '.claude-plugin/marketplace.json'
-const MARKETPLACE_PLUGIN = 'automate'
+const MARKETPLACES = [
+  {path: '.claude-plugin/marketplace.json', pluginName: 'automate'},
+  {path: '.cursor-plugin/marketplace.json', pluginName: 'automate'}
+]
 
 const CHANGELOG = 'CHANGELOG.md'
 const FIX_HINT = 'Run `pnpm run build:version` to fix this'
@@ -62,18 +65,23 @@ export function syncVersion(rootDir, {check = false} = {}) {
     }
   }
 
-  const market = readJson(MARKETPLACE)
-  const entry = Array.isArray(market.plugins) && market.plugins.find((p) => p.name === MARKETPLACE_PLUGIN)
-  if (!entry) {
-    errors.push(`${MARKETPLACE} has no plugins[] entry named "${MARKETPLACE_PLUGIN}"`)
-  }
-  else if (entry.version !== version) {
+  for (const {path, pluginName} of MARKETPLACES) {
+    const market = readJson(path)
+    const entry = Array.isArray(market.plugins) && market.plugins.find((p) => p.name === pluginName)
+    if (!entry) {
+      errors.push(`${path} has no plugins[] entry named "${pluginName}"`)
+      continue
+    }
+    if (entry.version === version) {
+      continue
+    }
+
     if (check) {
-      errors.push(`${MARKETPLACE} plugins["${MARKETPLACE_PLUGIN}"].version is ${JSON.stringify(entry.version)}, expected ${version}. ${FIX_HINT}.`)
+      errors.push(`${path} plugins["${pluginName}"].version is ${JSON.stringify(entry.version)}, expected ${version}. ${FIX_HINT}.`)
     }
     else {
       entry.version = version
-      writeJson(MARKETPLACE, market)
+      writeJson(path, market)
     }
   }
 

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -4,6 +4,7 @@
 // Source of truth: package.json `version`. Derived:
 //  - .claude-plugin/plugin.json        version
 //  - .codex/.codex-plugin/plugin.json  version
+//  - .cursor-plugin/plugin.json        version
 //  - gemini-extension.json             version
 //  - .claude-plugin/marketplace.json   plugins[name=automate].version  (NOT metadata.version, which is the marketplace catalog version)
 // CHANGELOG.md is handwritten and never rewritten here; this script only checks that its top `## X.Y.Z` entry matches the source version.
@@ -21,6 +22,7 @@ const SOURCE = 'package.json'
 const SIMPLE_TARGETS = [
   '.claude-plugin/plugin.json',
   '.codex/.codex-plugin/plugin.json',
+  '.cursor-plugin/plugin.json',
   'gemini-extension.json'
 ]
 

--- a/scripts/sync-version.test.js
+++ b/scripts/sync-version.test.js
@@ -25,6 +25,11 @@ function setupFixture(root, version = '1.2.0') {
 
   mkdirSync(join(root, '.cursor-plugin'), {recursive: true})
   writeJson(join(root, '.cursor-plugin/plugin.json'), {name: 'automate', version})
+  writeJson(join(root, '.cursor-plugin/marketplace.json'), {
+    name: 'kobiton',
+    metadata: {version: '1.0.0'},
+    plugins: [{name: 'automate', version}]
+  })
 
   writeJson(join(root, 'gemini-extension.json'), {name: 'kobiton-automate', version})
 
@@ -57,6 +62,7 @@ describe('syncVersion', () => {
       expect(readJson(dir, '.cursor-plugin/plugin.json').version).toBe('1.3.0')
       expect(readJson(dir, 'gemini-extension.json').version).toBe('1.3.0')
       expect(readJson(dir, '.claude-plugin/marketplace.json').plugins[0].version).toBe('1.3.0')
+      expect(readJson(dir, '.cursor-plugin/marketplace.json').plugins[0].version).toBe('1.3.0')
     })
 
     it('never touches marketplace metadata.version (the catalog version)', () => {

--- a/scripts/sync-version.test.js
+++ b/scripts/sync-version.test.js
@@ -23,6 +23,9 @@ function setupFixture(root, version = '1.2.0') {
   mkdirSync(join(root, '.codex/.codex-plugin'), {recursive: true})
   writeJson(join(root, '.codex/.codex-plugin/plugin.json'), {name: 'automate', version})
 
+  mkdirSync(join(root, '.cursor-plugin'), {recursive: true})
+  writeJson(join(root, '.cursor-plugin/plugin.json'), {name: 'automate', version})
+
   writeJson(join(root, 'gemini-extension.json'), {name: 'kobiton-automate', version})
 
   writeFileSync(join(root, 'CHANGELOG.md'), `# Changelog\n\n## ${version} - 2026-01-01\n\n- initial\n`)
@@ -42,7 +45,7 @@ describe('syncVersion', () => {
   })
 
   describe('write mode', () => {
-    it('propagates package.json version into all four manifests', () => {
+    it('propagates package.json version into all host manifests', () => {
       setupFixture(dir, '1.2.0')
       writeJson(join(dir, 'package.json'), {name: 'automate', version: '1.3.0', type: 'module'})
 
@@ -51,6 +54,7 @@ describe('syncVersion', () => {
 
       expect(readJson(dir, '.claude-plugin/plugin.json').version).toBe('1.3.0')
       expect(readJson(dir, '.codex/.codex-plugin/plugin.json').version).toBe('1.3.0')
+      expect(readJson(dir, '.cursor-plugin/plugin.json').version).toBe('1.3.0')
       expect(readJson(dir, 'gemini-extension.json').version).toBe('1.3.0')
       expect(readJson(dir, '.claude-plugin/marketplace.json').plugins[0].version).toBe('1.3.0')
     })

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -21,6 +21,10 @@ export function validateProject(rootDir) {
     '.agents/plugins/marketplace.json',
     '.codex/.codex-plugin/plugin.json',
     '.codex/.mcp.json',
+    '.cursor-plugin/plugin.json',
+    '.cursor-plugin/marketplace.json',
+    '.cursor/mcp.json',
+    '.cursor/hooks/hooks.json',
     'gemini-extension.json'
   ]
 
@@ -40,7 +44,7 @@ export function validateProject(rootDir) {
   }
 
   // Validate plugin.json required fields
-  for (const pluginPath of ['.claude-plugin/plugin.json', '.codex/.codex-plugin/plugin.json']) {
+  for (const pluginPath of ['.claude-plugin/plugin.json', '.codex/.codex-plugin/plugin.json', '.cursor-plugin/plugin.json']) {
     const filePath = join(rootDir, pluginPath)
     if (!existsSync(filePath)) {
       continue
@@ -88,6 +92,23 @@ export function validateProject(rootDir) {
       }
       else if (!mcp.mcpServers.kobiton.url) {
         fail('.codex/.mcp.json missing mcpServers.kobiton.url')
+      }
+    }
+    catch {
+      // Already caught by JSON validation above
+    }
+  }
+
+  // Validate .cursor/mcp.json (Cursor uses the same mcpServers shape as Claude)
+  const cursorMcpPath = join(rootDir, '.cursor/mcp.json')
+  if (existsSync(cursorMcpPath)) {
+    try {
+      const mcp = JSON.parse(readFileSync(cursorMcpPath, 'utf8'))
+      if (!mcp.mcpServers?.kobiton) {
+        fail('.cursor/mcp.json missing mcpServers.kobiton')
+      }
+      else if (!mcp.mcpServers.kobiton.url) {
+        fail('.cursor/mcp.json missing mcpServers.kobiton.url')
       }
     }
     catch {
@@ -180,8 +201,8 @@ export function validateProject(rootDir) {
     }
   }
 
-  // Validate referenced paths exist (Claude + Codex plugin manifests)
-  for (const pluginPath of ['.claude-plugin/plugin.json', '.codex/.codex-plugin/plugin.json']) {
+  // Validate referenced paths exist (Claude + Codex + Cursor plugin manifests)
+  for (const pluginPath of ['.claude-plugin/plugin.json', '.codex/.codex-plugin/plugin.json', '.cursor-plugin/plugin.json']) {
     const filePath = join(rootDir, pluginPath)
     if (!existsSync(filePath)) {
       continue

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -54,6 +54,28 @@ function setupValidProject(dir) {
     mcpServers: {kobiton: {httpUrl: 'https://api.kobiton.com/mcp'}}
   }))
 
+  mkdirSync(join(dir, '.cursor-plugin'))
+  writeFileSync(join(dir, '.cursor-plugin/plugin.json'), JSON.stringify({
+    name: 'automate',
+    version: '1.0.2',
+    description: 'Test',
+    mcpServers: './.cursor/mcp.json',
+    skills: './skills/'
+  }))
+  writeFileSync(join(dir, '.cursor-plugin/marketplace.json'), JSON.stringify({
+    name: 'kobiton',
+    owner: {name: 'Kobiton'},
+    plugins: [{name: 'automate', source: './', description: 'Test'}]
+  }))
+  mkdirSync(join(dir, '.cursor/hooks'), {recursive: true})
+  writeFileSync(join(dir, '.cursor/mcp.json'), JSON.stringify({
+    mcpServers: {kobiton: {url: 'https://api.kobiton.com/mcp'}}
+  }))
+  writeFileSync(join(dir, '.cursor/hooks/hooks.json'), JSON.stringify({
+    version: 1,
+    hooks: {sessionStart: [{command: 'bash ${CURSOR_PLUGIN_ROOT}/scripts/install-cli.sh'}]}
+  }))
+
   mkdirSync(join(dir, 'tools'))
   for (const file of ['devices.yaml', 'sessions.yaml', 'apps.yaml', 'user.yaml']) {
     writeFileSync(join(dir, 'tools', file), [

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -50,7 +50,7 @@ This skill calls tools served by the Kobiton MCP server at `api.kobiton.com/mcp`
 | `.mcp.json` (default) | OAuth 2.1 browser flow | Interactive AI-CLI session for an end user |
 | `.mcp.apikey-example.json` | Basic auth header — `Authorization: Basic base64(username:apikey)` from the `KOBITON_AUTH` env var | CI / headless / scripted invocations; copy this file over `.mcp.json` |
 
-If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate the Kobiton MCP server in their AI CLI before any device or session call can succeed. The exact invocation depends on the host (e.g. `/mcp` in Claude Code, `/mcp auth kobiton` in GitHub Copilot CLI and Gemini CLI, automatic browser flow on first tool call in Codex CLI — see the plugin README for current per-CLI commands). Do NOT attempt to recover by retrying — the auth context is fixed at session start.
+If the skill is invoked and no MCP connection is established, abort step 1 and surface a clear error: the user needs to authenticate the Kobiton MCP server in their AI CLI before any device or session call can succeed. The exact invocation depends on the host (e.g. `/mcp` in Claude Code, `/mcp auth kobiton` in GitHub Copilot CLI and Gemini CLI, automatic browser flow on first tool call in Codex CLI, `/mcp list` then Login in Cursor CLI — see the plugin README for current per-CLI commands). Do NOT attempt to recover by retrying — the auth context is fixed at session start.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary
- Adds Cursor CLI as a 5th supported host alongside Claude Code, Copilot CLI, Codex CLI, and Gemini CLI.
- Full plugin layout: `.cursor-plugin/plugin.json` + `marketplace.json` (cursor/plugins convention), `.cursor/mcp.json` for OAuth + API key, `.cursor/hooks/hooks.json` with a `sessionStart` event that auto-installs the `~/.kobiton/bin/kobiton` CLI wrapper.
- MCP requests originating from Cursor carry `X-AI-Tool-Name: Cursor` for adoption analytics (KOB-52724 pattern).

## What's done
- [x] `.cursor/mcp.json` — OAuth (default)
- [x] `.cursor/mcp.apikey-example.json` — API key auth for CI/headless (`${env:KOBITON_AUTH}`)
- [x] `.gitignore` — allow committed Cursor MCP configs + `.cursor/hooks/` through the ignore filter
- [x] `.cursor-plugin/plugin.json` — root manifest, paths to shared `skills/`, MCP config, and hooks
- [x] `.cursor-plugin/marketplace.json` — single-plugin entry under the Kobiton org
- [x] `.cursor/hooks/hooks.json` — `sessionStart` event running `install-cli.sh` via `${CURSOR_PLUGIN_ROOT}`
- [x] `scripts/validate.js` + tests — register and lint the four new JSON files (manifest, marketplace, MCP, hooks)
- [x] `scripts/sync-version.js` + tests — propagate `package.json` version into `.cursor-plugin/plugin.json`
- [x] `README.md` — Cursor CLI install section, login bullet, symlink-install behavior, update flow
- [x] `CHANGELOG.md` — `## 1.3.0 - 2026-05-28` entry
- [x] `package.json` bump → `1.3.0` (MINOR — new supported host) propagated to all five host manifests

## What's pending
- [ ] Smoke test on a real Cursor CLI install (`curl https://cursor.com/install | bash`, then clone into `~/.cursor/plugins/`) — verify `/mcp` shows `kobiton`, the OAuth browser flow works, and `~/.kobiton/bin/kobiton` is created by the sessionStart hook
- [ ] Verify `X-AI-Tool-Name: Cursor` reaches the MCP server (analytics dashboard)
- [ ] Optional follow-up: decide whether to expose `/automate:setup` and `/automate:doctor` as Cursor commands too (Cursor doesn't parse the Claude frontmatter, so they'd need a thin wrapper or a separate `.cursor/commands/` set)
- [ ] Optional follow-up: submit `.cursor-plugin/marketplace.json` to the official Cursor plugin marketplace once the install flow is validated

## References
- [Cursor Plugins Reference](https://cursor.com/docs/reference/plugins)
- [Cursor CLI MCP docs](https://cursor.com/docs/cli/mcp)
- [Cursor Hooks docs](https://cursor.com/docs/hooks)
- [cursor/plugins GitHub repo](https://github.com/cursor/plugins) (used as the structural reference for `plugin.json` and `marketplace.json`)

## Test plan
- [x] `pnpm run validate` passes (all 11 JSON files lint, version 1.3.0 in lockstep across 5 manifests, `.codex/` mirror in sync)
- [x] `pnpm test` passes (53/53 tests)
- [ ] Manual: install branch on Cursor CLI, run `/mcp` and confirm `kobiton` is Connected
- [ ] Manual: trigger a tool call (e.g. `listDevices`) and confirm OAuth browser flow
- [ ] Manual: verify `${CURSOR_PLUGIN_ROOT}/scripts/install-cli.sh` runs on session start and creates `~/.kobiton/bin/kobiton`