### PR TITLE
docs(contributing): align validation steps with validator's auto-discovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,12 +88,10 @@ Each skill file must have YAML frontmatter with `name` and `description`.
 
 ### Adding New Tools or Skills to Validation
 
-When you add a new tool YAML file or skill directory:
+`scripts/validate.js` auto-discovers tool YAMLs and skill directories via `readdirSync` — no manual array maintenance is required. When you add a new tool YAML file or skill directory:
 
-1. Add the filename to the `toolFiles` array in `scripts/validate.js`
-2. Add the skill directory name to the `skillDirs` array in `scripts/validate.js`
-3. Update the test fixtures in `scripts/validate.test.js` (`setupValidProject` function)
-4. Run `pnpm run validate && pnpm test` to confirm
+1. Update the test fixtures in `scripts/validate.test.js` (`setupValidProject` function) if your addition exercises a validation path not already covered
+2. Run `pnpm run validate && pnpm test` to confirm
 
 ### Validation
 


### PR DESCRIPTION
## What

Aligns CONTRIBUTING.md § "Adding New Tools or Skills to Validation" with what `scripts/validate.js` actually does.

The previous steps 1-2 told contributors:

```
1. Add the filename to the `toolFiles` array in `scripts/validate.js`
2. Add the skill directory name to the `skillDirs` array in `scripts/validate.js`
```

But there are no such arrays to maintain. `validate.js` uses `readdirSync` to discover tool YAMLs (line 125) and skill directories (line 164) at runtime. A contributor following the old instructions would search for array literals in the validator, find only `const`-declared `readdirSync` results, and either be confused or hand-edit the wrong thing.

Pure code-vs-doc reconciliation — no policy change. The kept steps (`setupValidProject` fixture + verify with validate/test) are the only contributor-side actions still required.

## Why filed separately

I noticed two adjacent docs items while preparing this fix, but they are content decisions Kobiton owns rather than bugs — flagging here for your call rather than including in this PR:

1. **README.md § Tools** says "13 MCP tools across 4 domains" and lists Devices + Sessions + Apps + Account. That count is internally correct, but the README doesn't include the 14 Test Case Management tools added in v1.2.2 / PR #82 (`tools/test-management.yaml`). If Test Case Management is intentionally not yet surfaced to README users, no change needed. If it should be documented there, happy to file a follow-up.

2. **AGENTS.md** lists `run-automation-suite` but not `run-interactive-test`. AGENTS.md was authored in PR #71 after `run-interactive-test` already existed (PR #45), so the omission looks intentional. If you want cross-host hosts (Gemini / Codex / Copilot) to know about `run-interactive-test` via AGENTS.md, happy to file a follow-up — with the macOS / Linux-x64 binary constraint clearly noted.

Both items are pre-existing; neither is in scope for this PR.

## Verification

- `pnpm run validate` clean
- `pnpm test` 5/5 files, 53/53 tests passing
- No code changes — docs only

- Jeremy Longshore
intentsolutions.io