### PR TITLE
feat(tools): add getAppParsingStatus tool schema + document async parsing in confirmAppUpload

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ A guide to every tool available in the Kobiton MCP server, organized by domain. 
 |---|--------|-------|
 | 1 | [Device Management](#1-device-management) | `listDevices`, `getDeviceStatus`, `reserveDevice`, `terminateReservation` |
 | 2 | [Session Management](#2-session-management) | `listSessions`, `getSession`, `getSessionArtifacts`, `terminateSession` |
-| 3 | [App Management](#3-app-management) | `listApps`, `getApp`, `uploadAppToStore`, `confirmAppUpload` |
+| 3 | [App Management](#3-app-management) | `listApps`, `getApp`, `uploadAppToStore`, `confirmAppUpload`, `getAppParsingStatus` |
 | 4 | [Running Automation Tests](#4-running-automation-tests) | `run-automation-suite` skill |
 
 ---
@@ -168,6 +168,18 @@ Confirm a previously uploaded app so it appears in the Kobiton portal's app repo
 > "Confirm the upload for app 42"
 
 > "Finish the upload process for the app I just uploaded"
+
+---
+
+### `getAppParsingStatus`
+
+Check whether an uploaded app version has finished parsing. After `confirmAppUpload` the app is parsed asynchronously, so poll this by `versionId` until the state is terminal (`OK` or a `FAILURE_*`) before reserving devices or starting a session.
+
+**Prompt examples:**
+
+> "Is the app I just uploaded done parsing yet?"
+
+> "Check the parsing status for app version 100"
 
 ---
 

--- a/tools/apps.yaml
+++ b/tools/apps.yaml
@@ -77,8 +77,12 @@ tools:
       Confirm a previously uploaded app so Kobiton parses the file and creates
       the app record. Call this after successfully uploading the file via PUT
       to the pre-signed URL returned by uploadAppToStore. Without this step
-      the file is orphaned in S3. Returns the appId and versionId of the
-      created app record.
+      the file is orphaned in S3. Returns the appId, versionId, and state of the
+      created app record. Parsing runs asynchronously: the app is created in
+      state PARSING, so poll getAppParsingStatus(versionId) until the state is
+      terminal (OK or a FAILURE_* value) before reserving devices or starting
+      sessions. confirmAppUpload may return appId: null for brand-new uploads -
+      use getAppParsingStatus(versionId), which resolves the real appId.
     annotations:
       readOnlyHint: false
       destructiveHint: false
@@ -103,6 +107,33 @@ tools:
         - userIntent
         - appPath
         - filename
+  - name: getAppParsingStatus
+    title: Get App Parsing Status
+    description: >
+      Check the async parse status of an uploaded app version. After
+      confirmAppUpload, the app is created with state PARSING and parsed
+      asynchronously - poll this tool by versionId until the state is terminal
+      (OK or a FAILURE_* value) before reserving devices or starting sessions.
+      Returns the resolved appId even when confirmAppUpload returned appId: null.
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    inputSchema:
+      type: object
+      properties:
+        userIntent:
+          type: string
+          description: >-
+            A brief summary of what the user is trying to accomplish with this
+            tool call, refined from their original prompt. Used for audit
+            logging.
+        versionId:
+          type: integer
+          description: The versionId returned by confirmAppUpload
+      required:
+        - userIntent
+        - versionId
   - name: getApp
     title: Get App
     description: >


### PR DESCRIPTION
## Summary

Adds the `getAppParsingStatus` MCP tool schema so agents can poll an uploaded app version's async parse state by `versionId`, and documents the async-parsing flow in `confirmAppUpload`. Pairs with the kobiton-api handler (Jira KOB-53331, F25). Interim F50 note: the confirm flow still targets `/v1/apps` (root migration tracked separately).

## Changes

- `tools/apps.yaml` — new `getAppParsingStatus` tool: `readOnlyHint: true` (idempotentHint omitted per the get* pattern), required `userIntent` + `versionId`. Updated `confirmAppUpload` description to state the app is created in `PARSING` and to poll `getAppParsingStatus(versionId)` until terminal (`OK` / `FAILURE_*`) before reserving devices / starting sessions; notes `appId` may be `null` → use `getAppParsingStatus`.
- `docs/examples.md` — `getAppParsingStatus` prompt examples + TOC row.

`pnpm run validate` (5 tools, `.codex/` mirror in sync) and `pnpm test` (105) pass locally.

## Live-once-both note

This is the schema half. The tool is advertised in `tools/list` only after this schema is published to S3 **and** the kobiton-api handler is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)