### PR TITLE
fix: background run-automation-suite launcher; ask observation mode up front

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "automate",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
       "author": {
         "name": "Kobiton Inc.",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.codex/.codex-plugin/plugin.json
+++ b/.codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.codex/skills/run-automation-suite/SKILL.md
+++ b/.codex/skills/run-automation-suite/SKILL.md
@@ -71,7 +71,7 @@ Wait for their response before proceeding. Do not call any upload or app-related
 
 **If reusing an existing app:** Check `appium:app` field of capabilities in the test script. Call `listApps` with that app version as keywork to check uploaded or not. Let the user pick the version to use (e.g., `kobiton-store:v72107`) if needed
 
-### 2. Select a device
+### 2. Select a device and ask how to observe the run
 
 Ask the user which device or platform to target.
 
@@ -80,6 +80,12 @@ Call `listDevices` with the relevant platform filter to show available options.
 If the user has a specific device in mind, confirm its availability with `getDeviceStatus`.
 
 Reserve the device with `reserveDevice` if needed.
+
+**In the same exchange, ask how they want to observe the run** — don't wait until the script is already running to raise it:
+
+> "Open the device live view in a browser window to watch the run, or run it in the background?"
+
+Remember the choice; act on it in Step 5 (which happens right after the script launches in Step 4). Do NOT auto-open a window without asking — some users prefer silent runs, especially on shared screens. If the user's request already made the preference clear (e.g. "just run it in the background", "open it so I can watch"), skip the question and honor what they said.
 
 ### 3. Identify script & parse capabilities
 
@@ -153,13 +159,11 @@ Wait for user confirmation, then execute the command **in the background** using
 
 ### 5. Open running session in browser
 
-Ask the user:
+Act on the observation choice the user already made in Step 2 — do **not** re-ask here.
 
-> "Would you like me to open the running session in the browser?"
+If they chose to **run in the background**, skip to Step 6.
 
-Wait for their response. If they decline, skip to Step 6.
-
-If they agree, wait **2 seconds** after the script was launched in Step 4 (to allow the session to initialize on Kobiton), then open the session in the user's browser.
+If they chose to **open the live view**, wait **2 seconds** after the script was launched in Step 4 (to allow the session to initialize on Kobiton), then open the session in the user's browser.
 
 **Determine the portal URL:** Read `.mcp.json` to get the MCP server URL, then derive the portal base URL by replacing the `api` host with the `portal` equivalent (drop any trailing `/mcp`):
 
@@ -203,7 +207,7 @@ All three presets share the same `920 px` height — only the width grows by dev
 
 If `getSession` / the rendered capabilities report `orientation=LANDSCAPE`, swap width and height (use the **Landscape** column above). Default is portrait.
 
-Pick the right command for the host OS:
+Pick the right command for the host OS. **Run it in the background** (Claude Code: `Bash` tool with `run_in_background: true`; other hosts: append `&` and `disown`) so the launcher's resize-polling loop doesn't block Step 6's result collection. The launcher's stdout/stderr and exit code surface later when it completes; the session URL printed above is the user's fallback if the launcher silently fails.
 
 | OS | Command |
 |----|---------|
@@ -215,7 +219,7 @@ Pick the right command for the host OS:
 
 **On macOS, the very first run** triggers a system prompt: *"X wants to control Google Chrome.app"* — click OK. The grant lives under System Settings → Privacy & Security → **Automation** (NOT Accessibility) and persists per host process. Tell the user this once if you can see it's their first invocation.
 
-**Launcher exit codes drive the fallback:**
+**Launcher exit codes drive the fallback** (they arrive in the background-task completion event, not synchronously):
 
 - `0` — Chrome was launched (resize may have logged a warning, but the session is fine). **Continue to Step 6.**
 - `2` — Chrome / Chromium is not installed on the host. **Fall through** to the default-browser fallback table below.
@@ -278,7 +282,7 @@ Present a summary to the user:
 
 On successful completion, the skill returns:
 
-- **Live session URL**: `https://portal.kobiton.com/devices/launch?id=<deviceId>`, opened automatically in the user's default browser as the script starts.
+- **Live session URL**: `https://portal.kobiton.com/devices/launch?id=<deviceId>` — opened in a browser window once the session starts **only if** the user chose to watch the run at Step 2; background runs skip the window and just surface the URL as text.
 - **Session metadata**: session ID, device ID, app version, start time, and final pass/fail status (via `getSession`).
 - **Session artifacts**: video recording URL, device logs URL, screenshots, and test reports (via `getSessionArtifacts`).
 - **Execution duration**: wall-clock time from script launch to completion.
@@ -300,13 +304,13 @@ On failure, the skill surfaces error output from the test runner, the session UR
 
 > "Run `./tests/checkout.js` on a Pixel 7 - upload the latest APK from `./build/app.apk` first."
 
-The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `listDevices` filtered to Pixel 7, reserves the device with `reserveDevice`, parses the script's capabilities, confirms the launch summary with the user, runs `node ./tests/checkout.js <udid>` in the background, opens the live session URL in the user's browser, and returns the session ID plus artifacts when the run completes.
+The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `listDevices` filtered to Pixel 7, reserves the device with `reserveDevice`, parses the script's capabilities, confirms the launch summary with the user (asking at device selection whether to watch the run or run it in the background), runs `node ./tests/checkout.js <udid>` in the background, opens the live session URL in the user's browser if they chose to watch, and returns the session ID plus artifacts when the run completes.
 
 ### Run an attached IPA with an attached script on a specific iOS device
 
 > "Test this app @TestApp.ipa by this script @automation.js on Kobiton iOS iPhone 15 Pro"
 
-The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user, runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser, and surfaces the session ID plus artifacts when the run completes.
+The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user (asking at device selection whether to watch the run or run it in the background), runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser if they chose to watch, and surfaces the session ID plus artifacts when the run completes.
 
 ## Resources
 

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "automate",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
       "author": {
         "name": "Kobiton Inc.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "automate",
   "displayName": "automate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,9 @@ Every tool call requires a `userIntent` argument summarizing what the user is tr
 Default workflow (mirrors the `run-automation-suite` skill):
 
 1. **Identify the app**: ask the user whether to upload a new app build or reuse an existing one. Do NOT auto-upload without confirmation. After `confirmAppUpload`, poll `getAppParsingStatus(versionId)` until the state is terminal (`OK` or a `FAILURE_*` value). See Known limitations.
-2. **Select a device**: call `listDevices` with the right platform filter. Confirm with the user before reserving.
+2. **Select a device and ask how to observe**: call `listDevices` with the right platform filter. Confirm with the user before reserving, and in the same exchange ask whether to open the device live view in a browser window or run in the background — ask this up front with the device, not after the script is already running. Skip the question if the user's request already made the preference clear.
 3. **Parse capabilities**: read the local Appium test script (Node / Python / .NET / Java), extract the capabilities literal, reconcile against the selected device per the must-match / suggested-default / user-controlled policy in `skills/run-automation-suite/references/capabilities.md`.
-4. **Confirm and execute**: present the summary, get user confirmation, run the script in the background, open the live-view URL.
+4. **Confirm and execute**: present the summary, get user confirmation, run the script in the background, then act on the step-2 observation choice — open the live-view URL only if the user asked to watch; otherwise leave it running silently.
 5. **Collect artifacts**: after the session terminates, call `getSession` + `getSessionArtifacts` for video, logs, screenshots, test reports. Surface session link + pass/fail.
 
 Detailed step-by-step instructions live in `skills/run-automation-suite/SKILL.md`. Hosts that support skills load it automatically; otherwise read the file directly for the full workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.7.1 - 2026-07-03
+
+### Fix: `run-automation-suite` launches the chromeless launcher in the background
+
+Step 5 now instructs the host to invoke the chromeless launcher in the background (Claude Code: `Bash` with `run_in_background: true`; other hosts: `&` + `disown`), matching `drive-automation-session`. Previously the synchronous invocation let the launcher's resize-polling loop block the skill from reaching Step 6 (session/result collection). Launcher exit codes now arrive in the background-task completion event rather than synchronously.
+
+### `run-automation-suite` asks how to observe the run up front
+
+The "open the live view or run in the background?" question now happens in Step 2 alongside device selection (mirroring `drive-automation-session`'s Step 0), instead of after the script has already launched in the old Step 5. Step 5 acts on the remembered choice without re-asking. `AGENTS.md` mirrors the reordering for non-Claude hosts.
+
 ## 1.7.0 - 2026-06-24
 
 KOB-53297 (Epic): the `getOrgSettings` tool plus the `create-test-run` and `monitor-test-run` skills for creating and watching test runs with live remediation.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kobiton-automate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "private": true,
   "description": "Kobiton plugin manifests, tool schemas, and skills for AI coding assistants",

--- a/skills/run-automation-suite/SKILL.md
+++ b/skills/run-automation-suite/SKILL.md
@@ -71,7 +71,7 @@ Wait for their response before proceeding. Do not call any upload or app-related
 
 **If reusing an existing app:** Check `appium:app` field of capabilities in the test script. Call `listApps` with that app version as keywork to check uploaded or not. Let the user pick the version to use (e.g., `kobiton-store:v72107`) if needed
 
-### 2. Select a device
+### 2. Select a device and ask how to observe the run
 
 Ask the user which device or platform to target.
 
@@ -80,6 +80,12 @@ Call `listDevices` with the relevant platform filter to show available options.
 If the user has a specific device in mind, confirm its availability with `getDeviceStatus`.
 
 Reserve the device with `reserveDevice` if needed.
+
+**In the same exchange, ask how they want to observe the run** — don't wait until the script is already running to raise it:
+
+> "Open the device live view in a browser window to watch the run, or run it in the background?"
+
+Remember the choice; act on it in Step 5 (which happens right after the script launches in Step 4). Do NOT auto-open a window without asking — some users prefer silent runs, especially on shared screens. If the user's request already made the preference clear (e.g. "just run it in the background", "open it so I can watch"), skip the question and honor what they said.
 
 ### 3. Identify script & parse capabilities
 
@@ -153,13 +159,11 @@ Wait for user confirmation, then execute the command **in the background** using
 
 ### 5. Open running session in browser
 
-Ask the user:
+Act on the observation choice the user already made in Step 2 — do **not** re-ask here.
 
-> "Would you like me to open the running session in the browser?"
+If they chose to **run in the background**, skip to Step 6.
 
-Wait for their response. If they decline, skip to Step 6.
-
-If they agree, wait **2 seconds** after the script was launched in Step 4 (to allow the session to initialize on Kobiton), then open the session in the user's browser.
+If they chose to **open the live view**, wait **2 seconds** after the script was launched in Step 4 (to allow the session to initialize on Kobiton), then open the session in the user's browser.
 
 **Determine the portal URL:** Read `.mcp.json` to get the MCP server URL, then derive the portal base URL by replacing the `api` host with the `portal` equivalent (drop any trailing `/mcp`):
 
@@ -203,7 +207,7 @@ All three presets share the same `920 px` height — only the width grows by dev
 
 If `getSession` / the rendered capabilities report `orientation=LANDSCAPE`, swap width and height (use the **Landscape** column above). Default is portrait.
 
-Pick the right command for the host OS:
+Pick the right command for the host OS. **Run it in the background** (Claude Code: `Bash` tool with `run_in_background: true`; other hosts: append `&` and `disown`) so the launcher's resize-polling loop doesn't block Step 6's result collection. The launcher's stdout/stderr and exit code surface later when it completes; the session URL printed above is the user's fallback if the launcher silently fails.
 
 | OS | Command |
 |----|---------|
@@ -215,7 +219,7 @@ Pick the right command for the host OS:
 
 **On macOS, the very first run** triggers a system prompt: *"X wants to control Google Chrome.app"* — click OK. The grant lives under System Settings → Privacy & Security → **Automation** (NOT Accessibility) and persists per host process. Tell the user this once if you can see it's their first invocation.
 
-**Launcher exit codes drive the fallback:**
+**Launcher exit codes drive the fallback** (they arrive in the background-task completion event, not synchronously):
 
 - `0` — Chrome was launched (resize may have logged a warning, but the session is fine). **Continue to Step 6.**
 - `2` — Chrome / Chromium is not installed on the host. **Fall through** to the default-browser fallback table below.
@@ -278,7 +282,7 @@ Present a summary to the user:
 
 On successful completion, the skill returns:
 
-- **Live session URL**: `https://portal.kobiton.com/devices/launch?id=<deviceId>`, opened automatically in the user's default browser as the script starts.
+- **Live session URL**: `https://portal.kobiton.com/devices/launch?id=<deviceId>` — opened in a browser window once the session starts **only if** the user chose to watch the run at Step 2; background runs skip the window and just surface the URL as text.
 - **Session metadata**: session ID, device ID, app version, start time, and final pass/fail status (via `getSession`).
 - **Session artifacts**: video recording URL, device logs URL, screenshots, and test reports (via `getSessionArtifacts`).
 - **Execution duration**: wall-clock time from script launch to completion.
@@ -300,13 +304,13 @@ On failure, the skill surfaces error output from the test runner, the session UR
 
 > "Run `./tests/checkout.js` on a Pixel 7 - upload the latest APK from `./build/app.apk` first."
 
-The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `listDevices` filtered to Pixel 7, reserves the device with `reserveDevice`, parses the script's capabilities, confirms the launch summary with the user, runs `node ./tests/checkout.js <udid>` in the background, opens the live session URL in the user's browser, and returns the session ID plus artifacts when the run completes.
+The skill detects the `.apk` build, uploads it via `uploadAppToStore`, queries `listDevices` filtered to Pixel 7, reserves the device with `reserveDevice`, parses the script's capabilities, confirms the launch summary with the user (asking at device selection whether to watch the run or run it in the background), runs `node ./tests/checkout.js <udid>` in the background, opens the live session URL in the user's browser if they chose to watch, and returns the session ID plus artifacts when the run completes.
 
 ### Run an attached IPA with an attached script on a specific iOS device
 
 > "Test this app @TestApp.ipa by this script @automation.js on Kobiton iOS iPhone 15 Pro"
 
-The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user, runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser, and surfaces the session ID plus artifacts when the run completes.
+The skill resolves the two `@`-referenced files from the chat context, uploads `TestApp.ipa` via `uploadAppToStore`, queries `listDevices` filtered to iOS iPhone 15 Pro, reserves the matching device, parses `automation.js` for capabilities, reconciles them against the rendered defaults for the selected device, confirms the launch summary with the user (asking at device selection whether to watch the run or run it in the background), runs `node automation.js <udid>` in the background, opens the live session URL in the user's browser if they chose to watch, and surfaces the session ID plus artifacts when the run completes.
 
 ## Resources
 


### PR DESCRIPTION
## What

Two fixes to `run-automation-suite`, both mirroring how `drive-automation-session` already handles the live-view launcher:

1. **Background the chromeless launcher.** Step 5 now instructs the host to invoke the launcher in the background (Claude Code: `Bash` with `run_in_background: true`; other hosts: `&` + `disown`). Previously it ran synchronously, so the launcher's resize-polling loop blocked the skill from reaching Step 6 (session/result collection). Launcher exit codes now arrive via the background-task completion event rather than synchronously.

2. **Ask observation mode up front.** The "open the live view or run in the background?" question moves from the old Step 5 (asked *after* the script already launched) to Step 2, alongside device selection — the same up-front pattern as `drive-automation-session`'s Step 0. Step 5 acts on the remembered choice without re-asking, and honors an already-stated preference.

## Cross-host parity

`AGENTS.md` steps 2 and 4 updated to match, so non-Claude hosts follow the same ordering. `.codex/` mirror regenerated via `pnpm run build:codex`.

## Version

Bumped to `1.7.1` (`package.json` source of truth, propagated to all manifests via `pnpm run build:version`; CHANGELOG entry added).

## Testing

`pnpm run validate` passes (manifests, mirror parity, version + CHANGELOG match). `pnpm test` — 189/189 pass. Docs-only skill/manifest change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)