### PR TITLE
feat(tools): add getAyaIdentityAssertion tool schema (KOB-54275)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ There is no local way to test that a new tool YAML matches a deployed server-sid
 
 ### Tool inventory
 
-`tools/` holds 5 YAML files auto-discovered by `scripts/validate.js` (no manual array maintenance):
+`tools/` holds 6 YAML files auto-discovered by `scripts/validate.js` (no manual array maintenance):
 
 | File | Tools |
 |---|---|
@@ -51,6 +51,7 @@ There is no local way to test that a new tool YAML matches a deployed server-sid
 | `tools/apps.yaml` | `listApps`, `uploadAppToStore`, `confirmAppUpload`, `getAppParsingStatus`, `getApp` |
 | `tools/user.yaml` | `getCredential` |
 | `tools/test-management.yaml` | 14 test-case / test-run / test-suite CRUD tools |
+| `tools/aya.yaml` | `getAyaIdentityAssertion` |
 
 `tools/devices.yaml`, `tools/sessions.yaml`, `tools/apps.yaml` set the full 4-hint annotation block (`readOnlyHint`, `destructiveHint`, `idempotentHint` where meaningful, `openWorldHint: false`). `tools/user.yaml` and `tools/test-management.yaml` currently use the older 2-hint shape (`readOnlyHint` + `destructiveHint` only) — when modifying those files, prefer adding the missing hints rather than leaving them inconsistent.
 

--- a/tools/aya.yaml
+++ b/tools/aya.yaml
@@ -1,0 +1,31 @@
+domain: AYA
+tools:
+  - name: getAyaIdentityAssertion
+    title: Get AYA Identity Assertion
+    description: >
+      Return a short-lived signed identity assertion (a JWT, RS256, expires in
+      60 seconds) proving the current OAuth-authenticated user's Kobiton
+      identity. Ask Your App (AYA, askyourapp.ai) accepts this assertion to
+      establish a session for the same user without a browser sign-in; it
+      verifies the signature against Kobiton's published JWKS endpoint
+      (/.well-known/jwks.json). The assertion is proof of the caller's own
+      identity only - it grants no access by itself and expires quickly, so
+      request it immediately before use. Aside from userIntent, the tool
+      accepts no input - it operates on the authenticated user from the OAuth
+      context. Returns an error if the environment has no assertion signing
+      key configured.
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    inputSchema:
+      type: object
+      properties:
+        userIntent:
+          type: string
+          description: >-
+            A brief summary of what the user is trying to accomplish with this
+            tool call, refined from their original prompt. Used for audit
+            logging.
+      required:
+        - userIntent


### PR DESCRIPTION
## Summary

Adds the `getAyaIdentityAssertion` tool schema (new AYA domain, `tools/aya.yaml`). The tool returns a short-lived signed identity assertion (RS256 JWT, 60-second expiry) proving the OAuth-authenticated user's Kobiton identity. Ask Your App (askyourapp.ai) accepts the assertion to establish a session for the same user without a browser sign-in, verifying it against Kobiton's published JWKS endpoint (`/.well-known/jwks.json`).

## Changes

- `tools/aya.yaml` — one tool, read-only annotation pattern (`readOnlyHint: true`, `destructiveHint: false`, `openWorldHint: false`), `userIntent`-only input per the registry contract.
- `CLAUDE.md` — tool inventory table updated (6 YAML files).

## Notes

- **No version bump in this PR** — the tool contract ships to the server via the S3 `tool-definitions.yaml` publish, decoupled from a plugin release; 1.8.0 is already claimed by the open #100.
- Server-side handler ships in kobiton/api PR #5072 (functional verification happens after that deploys, per the repo's tool-YAML contract note).
- `pnpm run validate` + full vitest suite (189) green; `build:tools` emits the tool into `dist/tool-definitions.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)