### PR TITLE
KOB-54335: replace the app tools with a unified promptApp

### DIFF
--- a/tools/aya.yaml
+++ b/tools/aya.yaml
@@ -29,3 +29,77 @@ tools:
             logging.
       required:
         - userIntent
+
+  - name: listAyaApps
+    title: List Apps Available in AYA
+    description: >
+      List every app the user can ask AYA about: their own uploaded apps first,
+      then AYA's public app catalog. Call this before any other AYA app tool to
+      obtain an appId. The same bundleId may appear twice - once as the user's
+      private copy (isPublic false) and once as the public catalog copy
+      (isPublic true); these are separate apps with separate crawl data, so
+      state which one you mean. An app with crawlCount 0 or a null
+      firstCrawledAt has not been crawled yet and cannot answer questions.
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    inputSchema:
+      type: object
+      properties:
+        q:
+          type: string
+          description: >-
+            Optional case-insensitive substring filter on app name and bundle
+            id. Exact substring only, not fuzzy - prefer omitting it and
+            filtering the results when unsure of the exact name.
+        limit:
+          type: integer
+          description: Maximum apps to return, 1-200, default 50.
+        userIntent:
+          type: string
+          description: >-
+            A brief summary of what the user is trying to accomplish with this
+            tool call, refined from their original prompt. Used for audit
+            logging.
+      required:
+        - userIntent
+
+  - name: askYourApp
+    title: Ask Your App
+    description: >
+      Answer a natural-language question about an app AYA has already crawled,
+      using its screen and flow knowledge graph. Identify the app by its AYA
+      appId from listAyaApps - never by bundle id, because one bundle id can
+      refer to both the user's private copy and the public catalog copy. Pass
+      conversationId from a previous result to ask a follow-up in the same
+      conversation; omit it to start a new one. Always pass the appId, including
+      on follow-ups. Returns an error if the app has not been crawled yet.
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    inputSchema:
+      type: object
+      properties:
+        appId:
+          type: string
+          description: AYA app UUID, as returned by listAyaApps.
+        question:
+          type: string
+          description: The natural-language question about the app's flows or behavior.
+        conversationId:
+          type: string
+          description: >-
+            Optional AYA conversation id from a previous askYourApp result, to
+            continue that conversation. Must belong to the same appId.
+        userIntent:
+          type: string
+          description: >-
+            A brief summary of what the user is trying to accomplish with this
+            tool call, refined from their original prompt. Used for audit
+            logging.
+      required:
+        - appId
+        - question
+        - userIntent

--- a/tools/aya.yaml
+++ b/tools/aya.yaml
@@ -30,76 +30,54 @@ tools:
       required:
         - userIntent
 
-  - name: listAyaApps
-    title: List Apps Available in AYA
+  - name: promptApp
+    title: Prompt About an App
     description: >
-      List every app the user can ask AYA about: their own uploaded apps first,
-      then AYA's public app catalog. Call this before any other AYA app tool to
-      obtain an appId. The same bundleId may appear twice - once as the user's
-      private copy (isPublic false) and once as the public catalog copy
-      (isPublic true); these are separate apps with separate crawl data, so
-      state which one you mean. An app with crawlCount 0 or a null
-      firstCrawledAt has not been crawled yet and cannot answer questions.
+      Ask a question in natural language about mobile apps and get an answer back.
+      One tool covers the whole surface: which apps are available to you, details
+      about a specific app, exploring an app to learn its screens and flows, how a
+      running exploration is progressing, and questions about an explored app's
+      behaviour - including the selector for a specific button or field, which is
+      what you want when writing an automation script. There is no action or mode
+      to choose: phrase the request naturally ("which apps can I ask about?",
+      "explore my Shop app", "is the explore finished?", "how does checkout work in
+      Acme Shopper?", "what is the selector for the Add to cart button?") and it is
+      routed for you. Pass conversationId from a previous result to keep context;
+      omit it to start fresh. If the answer comes back with conversationStarted
+      true, the previous conversation was not found and this is a new one, so
+      earlier context is gone. If it comes back with proposedAction, an action needs
+      a person to approve it - show the user the approval link rather than trying to
+      continue on your own. Only apps already in the system can be explored or
+      described.
     annotations:
-      readOnlyHint: true
+      readOnlyHint: false
       destructiveHint: false
       openWorldHint: false
     inputSchema:
       type: object
       properties:
-        q:
-          type: string
-          description: >-
-            Optional case-insensitive substring filter on app name and bundle
-            id. Exact substring only, not fuzzy - prefer omitting it and
-            filtering the results when unsure of the exact name.
-        limit:
-          type: integer
-          description: Maximum apps to return, 1-200, default 50.
-        userIntent:
-          type: string
-          description: >-
-            A brief summary of what the user is trying to accomplish with this
-            tool call, refined from their original prompt. Used for audit
-            logging.
-      required:
-        - userIntent
-
-  - name: askYourApp
-    title: Ask Your App
-    description: >
-      Answer a natural-language question about an app AYA has already crawled,
-      using its screen and flow knowledge graph. Identify the app by its AYA
-      appId from listAyaApps - never by bundle id, because one bundle id can
-      refer to both the user's private copy and the public catalog copy. Pass
-      conversationId from a previous result to ask a follow-up in the same
-      conversation; omit it to start a new one. Always pass the appId, including
-      on follow-ups. Returns an error if the app has not been crawled yet.
-    annotations:
-      readOnlyHint: true
-      destructiveHint: false
-      openWorldHint: false
-    inputSchema:
-      type: object
-      properties:
-        appId:
-          type: string
-          description: AYA app UUID, as returned by listAyaApps.
         question:
           type: string
-          description: The natural-language question about the app's flows or behavior.
+          description: >-
+            The request in plain language. Anything from "list my apps" to a
+            specific question about one app's flows or element selectors.
         conversationId:
           type: string
           description: >-
-            Optional AYA conversation id from a previous askYourApp result, to
-            continue that conversation. Must belong to the same appId.
+            Optional. The conversationId from a previous promptApp result, to
+            continue that conversation. Omit it on a first question. Pass it back
+            exactly as received - do not construct or reuse one you have not been
+            given.
+        bundleId:
+          type: string
+          description: >-
+            Optional hint naming the app's bundle id when you already know it. Not
+            required - the app is usually resolved from the question itself.
         userIntent:
           type: string
           description: >-
             A brief summary of what the user is trying to accomplish with this
-            tool call, refined from their original prompt. Used for audit
-            logging.
+            tool call, refined from their original prompt. Used for audit logging.
       required:
-        - appId
         - question
         - userIntent

--- a/tools/sessions.yaml
+++ b/tools/sessions.yaml
@@ -174,3 +174,117 @@ tools:
       required:
         - userIntent
         - sessionId
+  - name: startNativeSession
+    title: Start Native Session
+    description: >
+      Start a native automation session on a Kobiton device using a native test
+      framework — XCUITest (iOS), UIAutomator (Android), or GameDriver. Upload
+      the app under test and the test-runner bundle to Kobiton Store first
+      (uploadAppToStore) and pass their kobiton-store identifiers as `app` and
+      `testRunner`. Returns the created session ID plus the booked device UDID
+      and a test-report download URL. This starts a real, billable device
+      session — prefer listDevices first to confirm a matching device is
+      available.
+    annotations:
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+    inputSchema:
+      type: object
+      properties:
+        userIntent:
+          type: string
+          description: >-
+            A brief summary of what the user is trying to accomplish with this
+            tool call, refined from their original prompt. Used for audit
+            logging.
+        testFramework:
+          type: string
+          enum:
+            - XCUITEST
+            - UIAUTOMATOR
+            - GAMEDRIVER
+          description: >-
+            Native test framework to run. Exact upper-case values required.
+            XCUITEST is iOS-only; UIAUTOMATOR is Android-only.
+        sessionName:
+          type: string
+          description: Optional name for the session
+        sessionDescription:
+          type: string
+          description: Optional description for the session
+        deviceName:
+          type: string
+          description: >-
+            Device name to match (e.g. "Galaxy S21"). Ignored when `udid` is
+            given.
+        udid:
+          type: string
+          description: >-
+            Exact device UDID to run on. Takes precedence over deviceName /
+            platformVersion matching.
+        platformVersion:
+          type: string
+          description: OS version to match (e.g. "14", "17.4")
+        deviceGroup:
+          type: string
+          enum:
+            - KOBITON
+            - ORGANIZATION
+            - CLOUD
+          description: >-
+            Which device pool to book from. KOBITON = Kobiton cloud devices,
+            ORGANIZATION = your organization's own devices.
+        groupId:
+          type: integer
+          description: Team ID to run the session under
+        app:
+          type: string
+          description: >-
+            App under test, as a kobiton-store:<appId> identifier returned by
+            uploadAppToStore
+        testRunner:
+          type: string
+          description: >-
+            Test runner bundle (XCUITest test-runner .ipa, UIAutomator test
+            .apk, or GameDriver runner), as a kobiton-store:<appId> identifier
+        noReset:
+          type: boolean
+          description: Keep app data between runs (do not reset the app)
+        fullReset:
+          type: boolean
+          description: Uninstall and reinstall the app before the run
+        sessionTimeout:
+          type: integer
+          description: Maximum session duration in minutes (default 60)
+        testTimeout:
+          type: integer
+          description: Maximum test execution time in minutes
+        deviceTags:
+          type: array
+          description: Only book devices carrying all of these device tags
+          items:
+            type: string
+        deviceWaitTimeout:
+          type: integer
+          description: >-
+            How long (in seconds, 1-86400) to wait for a matching device to
+            become available before failing. Only honored for queued
+            executions.
+        runCommand:
+          type: string
+          description: GameDriver only — command line used to launch the runner
+        args:
+          type: array
+          description: Extra arguments passed to the test runner
+          items:
+            type: string
+        env:
+          type: object
+          description: Environment variables to set for the test runner process
+          additionalProperties:
+            type: string
+      required:
+        - userIntent
+        - testFramework


### PR DESCRIPTION
Replaces the two app tools on this branch with a single **`promptApp`**, and carries `startNativeSession` across from KOB-54362 so the published catalog keeps it.

> **Scope changed mid-review.** This PR originally added `listAyaApps` + `askYourApp`. The ticket was rewritten to one unified tool and the branch was reworked in `8f151407`.

## One tool, no action parameter

`promptApp` takes a plain-language `question` and nothing else is required. The server routes the request itself — listing apps, app detail, exploring an app, explore status, and questions about an explored app's flows all go through the same tool. There is no action enum to pick from, because the backend decides how many of its own tools to run behind a single call.

The description carries the three things a model can't infer from the schema:

- **Conversation threading** — pass `conversationId` back to continue; omit it to start fresh.
- **`conversationStarted: true` means the previous conversation was not found**, so earlier context is gone. Without this a model would keep referring to a thread the server has already dropped.
- **`proposedAction` means a human must approve** — surface the link rather than trying to continue. Exploring an app spends real device time, so it is deliberately gated.

Selector lookups are called out explicitly ("what is the selector for the Add to cart button?"), since that is the main draw for automation work and not obvious from a tool named `promptApp`.

## Naming

No product name appears in the tool or its parameters — the underlying integration may still be renamed, and a tool name is a public contract that is painful to change later.

## `startNativeSession`

This branch is cut from `aya-develop`, which predates the `sessions.yaml` change on KOB-54362. Building the published catalog from this branch alone would have **silently dropped** that tool: it is registered server-side and live in the published catalog, and a handler with no schema entry simply stops appearing in clients' tool lists with no error anywhere.

The two branches touch disjoint files — that one owns `sessions.yaml`, this one owns `aya.yaml` — so taking it wholesale gives the correct union. Caught by diffing the built catalog against the **published** one, not just against this branch.

## Verification

`pnpm run validate` passes (`tools/aya.yaml is valid (2 tools)`, `tools/sessions.yaml is valid (6 tools)`, `.codex/` mirror in sync), `pnpm test` passes, and `pnpm run build:tools` emits a catalog whose only delta against the currently published one is `+promptApp / −listAyaApps / −askYourApp`.

Schema-only, as always in this repo — the handlers live server-side, and the names here match the registered handlers exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
