### PR TITLE
docs: correct Cursor UI labels and add the missing Cursor API key note

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ For CI/CD pipelines or headless environments that cannot open a browser, use API
 
 > **Note:** OAuth and API key auth cannot coexist in a single `.mcp.json` (the API key config sets an `Authorization` header that OAuth must not have). To switch, replace `.mcp.json` with the appropriate format from `.mcp.apikey-example.json`.
 >
+> **`/automate:setup` does not work under API key auth.** It fetches your credentials through an *OAuth-authenticated* MCP session to write `~/.kobiton/.credentials`. Per the [skill compatibility matrix](CLAUDE.md#skill-compatibility-matrix), three skills read that file directly and have no MCP fallback, so they are unavailable on API key auth: `run-interactive-session`, `drive-automation-session`, and `monitor-test-run`. The MCP tools, `run-automation-suite` (your script carries its own credentials), and `create-test-run` (pure MCP) are unaffected.
+>
 > **Gemini CLI:** API key auth requires editing `gemini-extension.json` instead of `.mcp.json`. Add a `headers` block under `mcpServers.kobiton` with `"Authorization": "${KOBITON_AUTH}"`.
 >
 > **Cursor (CLI and IDE):** API key auth requires editing `.cursor/mcp.json` instead of `.mcp.json` - that is the file the plugin manifest points `mcpServers` at. Cursor expands `${env:NAME}`, not the bare `${NAME}` other clients use, so start from `.cursor/mcp.apikey-example.json` rather than another client's config:

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The Cursor desktop editor installs the plugin from its built-in plugin browser:
 1. Open **Cursor Settings** > **Plugins** and paste `https://github.com/kobiton/automate` into the search box
 2. Click the **automate** result, then **Add to Cursor**, then **Install**
 
-To authenticate with the Kobiton MCP server: open **Tool & MCPs**, search for **kobiton**, click **Connect**, and complete the OAuth login in the browser.
+To authenticate with the Kobiton MCP server: open **Tool & MCPs**, search for **kobiton**, click **Authenticate**, and complete the OAuth login in the browser.
 
 > **Using both Cursor CLI and the Cursor IDE?** They share plugin installs: a plugin installed from the `agent` CLI shows up in the IDE, and vice versa. Install the plugin **once** in either one, installing it in both registers the skills, commands, and MCP server twice.
 
@@ -236,8 +236,8 @@ You can also trigger or inspect authentication explicitly:
 - **GitHub Copilot CLI**: type `/mcp auth kobiton` to start the OAuth flow; use `/mcp` (or `/mcp show`) to inspect server status
 - **Gemini CLI**: type `/mcp auth kobiton` to start the OAuth flow; use `/mcp` to inspect server status
 - **Codex CLI**: browser opens automatically on the first MCP tool call (e.g. *"List my Kobiton devices"*) after plugin install. Tokens are cached in the OS keychain with automatic refresh. Use `/mcp` (or `/mcp verbose`) to inspect server status
-- **Cursor CLI**: run `/mcp list`, select **kobiton**, and choose **Login** to start the OAuth flow; tokens are stored by Cursor in the OS keychain
-- **Cursor IDE**: open **Cursor Settings** > **Tool & MCPs**, search for **kobiton**, and click **Connect** to start the OAuth flow
+- **Cursor CLI**: run `/mcp list`, select **Kobiton**, and choose **Login** to start the OAuth flow; tokens are stored by Cursor in the OS keychain
+- **Cursor IDE**: open **Cursor Settings** > **Tool & MCPs**, search for **kobiton**, and click **Authenticate** to start the OAuth flow
 
 Behind the scenes, `.mcp.json` points to the Kobiton MCP server and authentication uses OAuth 2.1:
 
@@ -274,6 +274,8 @@ For CI/CD pipelines or headless environments that cannot open a browser, use API
 > **Note:** OAuth and API key auth cannot coexist in a single `.mcp.json` (the API key config sets an `Authorization` header that OAuth must not have). To switch, replace `.mcp.json` with the appropriate format from `.mcp.apikey-example.json`.
 >
 > **Gemini CLI:** API key auth requires editing `gemini-extension.json` instead of `.mcp.json`. Add a `headers` block under `mcpServers.kobiton` with `"Authorization": "${KOBITON_AUTH}"`.
+>
+> **Cursor (CLI and IDE):** API key auth requires editing `.cursor/mcp.json` instead of `.mcp.json` - that is the file the plugin manifest points `mcpServers` at. Cursor expands `${env:NAME}`, not the bare `${NAME}` other clients use, so copy `.cursor/mcp.apikey-example.json` rather than another client's config. A project-level `.cursor/mcp.json` survives plugin updates; the plugin's own copy lives in the version-pinned plugin cache and is replaced on reinstall.
 >
 > **Codex CLI:** OAuth is the default. For CI/headless environments where a browser cannot open, switch to API key auth by adding an `env_http_headers` block to the plugin's `.mcp.json`, then export `KOBITON_AUTH` in the shell that launches `codex`:
 >

--- a/README.md
+++ b/README.md
@@ -275,7 +275,14 @@ For CI/CD pipelines or headless environments that cannot open a browser, use API
 >
 > **Gemini CLI:** API key auth requires editing `gemini-extension.json` instead of `.mcp.json`. Add a `headers` block under `mcpServers.kobiton` with `"Authorization": "${KOBITON_AUTH}"`.
 >
-> **Cursor (CLI and IDE):** API key auth requires editing `.cursor/mcp.json` instead of `.mcp.json` - that is the file the plugin manifest points `mcpServers` at. Cursor expands `${env:NAME}`, not the bare `${NAME}` other clients use, so copy `.cursor/mcp.apikey-example.json` rather than another client's config. A project-level `.cursor/mcp.json` survives plugin updates; the plugin's own copy lives in the version-pinned plugin cache and is replaced on reinstall.
+> **Cursor (CLI and IDE):** API key auth requires editing `.cursor/mcp.json` instead of `.mcp.json` - that is the file the plugin manifest points `mcpServers` at. Cursor expands `${env:NAME}`, not the bare `${NAME}` other clients use, so start from `.cursor/mcp.apikey-example.json` rather than another client's config:
+>
+> ```bash
+> mkdir -p .cursor
+> curl -sL -o .cursor/mcp.json https://raw.githubusercontent.com/kobiton/automate/main/.cursor/mcp.apikey-example.json
+> ```
+>
+> A project-level `.cursor/mcp.json` survives plugin updates; the plugin's own copy lives in the version-pinned plugin cache and is replaced on reinstall.
 >
 > **Codex CLI:** OAuth is the default. For CI/headless environments where a browser cannot open, switch to API key auth by adding an `env_http_headers` block to the plugin's `.mcp.json`, then export `KOBITON_AUTH` in the shell that launches `codex`:
 >


### PR DESCRIPTION
Three wrong UI labels and one missing client note, all found while writing the Cursor setup guides for the docs site ([kobiton/docs#547](https://github.com/kobiton/docs/pull/547), [KOB-53278](https://kobiton.atlassian.net/browse/KOB-53278)).

Everything here was verified against live Cursor CLI and Cursor IDE installs, and against the installed plugin on disk.

## UI label corrections

| Line | Was | Now |
|---|---|---|
| L166 | Cursor IDE: click **Connect** | **Authenticate** |
| L239 | Cursor CLI: select **kobiton** | **Kobiton** |
| L240 | Cursor IDE: click **Connect** | **Authenticate** |

L153 already said **Kobiton** and is unchanged, which is what flagged the inconsistency in the first place.

Worth noting the server name genuinely differs by surface: **Kobiton** in the Cursor CLI `/mcp list`, lowercase **kobiton** in the Cursor IDE **Tool & MCPs** panel. Both are left as they are, since both are correct.

## Missing Cursor entry under API Key Authentication

The note carries per-client guidance for Gemini CLI and Codex CLI but had nothing for Cursor, even though Cursor needs a different file *and* different variable syntax than any other client:

- Cursor reads `.cursor/mcp.json`, declared as `mcpServers` in `.cursor-plugin/plugin.json`. Not the root `.mcp.json`, which is the Claude Code config and sends `X-AI-Tool-Name: Claude`.
- Cursor expands `${env:NAME}`. Every other client uses a bare `${NAME}`.

That second point is the costly one. Copying another client's config produces no error. Cursor sends the literal string `${KOBITON_AUTH}` as the `Authorization` header and auth just fails.

The repo already ships the right template at `.cursor/mcp.apikey-example.json`; the note now points at it, and covers the plugin-cache versus project-level placement tradeoff.

## Note for reviewers

I only have READ on this repo, so this comes from a fork. Happy to hand the patch over if you would rather land it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOB-53278]: https://kobiton.atlassian.net/browse/KOB-53278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ