### PR TITLE
docs: document the getOrgSettings tool and add a Documentation Parity rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Kobiton is a real-device mobile cloud for Android + iOS testing. This MCP plugin
 - **Apps**: list, upload, confirm upload, get parsing status, get details
 - **Sessions**: list, get, get artifacts, get user-input events, terminate
 - **Test management**: create / list / get / update / delete test cases, test runs, and test suites; `saveTestCase` converts a finished manual session into a reusable test case
-- **Setup**: `getCredential` (used by `/automate:setup`)
+- **Account**: `getCredential` (used by `/automate:setup`); `getOrgSettings` for org-level feature flags such as live remediation
 
 The MCP server runs at `https://api.kobiton.com/mcp`. Authentication is OAuth 2.1 (default) or API key (CI/headless).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ CI runs `pnpm install --frozen-lockfile && pnpm run validate && pnpm test` on ev
 
 | File | Covers |
 |---|---|
-| `scripts/validate.test.js` | structural validation across manifests, tool YAMLs, skill frontmatter |
+| `scripts/validate.test.js` | structural validation across manifests, tool YAMLs, skill frontmatter, README tool parity |
 | `scripts/build-tool-definitions.test.js` | tool-definition YAML concatenation |
 | `scripts/sync-codex-artifacts.test.js` | `.codex/` mirror sync + `--check` parity |
 | `scripts/sync-version.test.js` | version field sync across host manifests + `CHANGELOG.md` top-entry match |
@@ -161,7 +161,7 @@ When modifying `scripts/install-cli.sh` (or adding any new script that hooks inv
 
 ## Tool schema conventions
 
-`scripts/validate.js` auto-discovers tool YAMLs. To add a tool: drop a YAML in `tools/` and run `pnpm run validate`. No `validate.js` edit required.
+`scripts/validate.js` auto-discovers tool YAMLs. To add a tool: drop a YAML in `tools/`, add its row to the README `## Tools` table and bump the "N MCP tools" count (validate fails otherwise), and run `pnpm run validate`. No `validate.js` edit required.
 
 **Annotation hints currently in use** — pattern by tool verb (matches the as-of-today YAML, not aspiration):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,10 @@ There is no local way to test that a new tool YAML matches a deployed server-sid
 | `tools/devices.yaml` | `listDevices`, `getDeviceStatus`, `reserveDevice`, `terminateReservation` |
 | `tools/sessions.yaml` | `listSessions`, `getSession`, `getSessionArtifacts`, `getUserInputEvents`, `terminateSession` |
 | `tools/apps.yaml` | `listApps`, `uploadAppToStore`, `confirmAppUpload`, `getAppParsingStatus`, `getApp` |
-| `tools/user.yaml` | `getCredential` |
+| `tools/user.yaml` | `getCredential`, `getOrgSettings` |
 | `tools/test-management.yaml` | 14 test-case / test-run / test-suite CRUD tools |
 
-`tools/devices.yaml`, `tools/sessions.yaml`, `tools/apps.yaml` set the full 4-hint annotation block (`readOnlyHint`, `destructiveHint`, `idempotentHint` where meaningful, `openWorldHint: false`). `tools/user.yaml` and `tools/test-management.yaml` currently use the older 2-hint shape (`readOnlyHint` + `destructiveHint` only) — when modifying those files, prefer adding the missing hints rather than leaving them inconsistent.
+`tools/devices.yaml`, `tools/sessions.yaml`, `tools/apps.yaml`, and `tools/user.yaml` set the full annotation block (`readOnlyHint`, `destructiveHint`, `idempotentHint` where meaningful, `openWorldHint: false`). `tools/test-management.yaml` currently uses the older 2-hint shape (`readOnlyHint` + `destructiveHint` only) — when modifying that file, prefer adding the missing hints rather than leaving them inconsistent.
 
 ### Skills
 
@@ -174,7 +174,7 @@ When modifying `scripts/install-cli.sh` (or adding any new script that hooks inv
 
 `idempotentHint` is omitted on `readOnlyHint: true` tools per MCP 2025-06-18 — the field is defined as meaningful only for non-read-only operations, so an explicit value adds noise. `terminate*` carries `idempotentHint: true` because a repeat-terminate against an already-terminated resource is a no-op (HTTP DELETE pattern).
 
-The `test-management.yaml` and `user.yaml` tools currently ship the older 2-hint subset (`readOnlyHint` + `destructiveHint` only); when touching those files, extend with `idempotentHint` and `openWorldHint: false` per the patterns above.
+The `test-management.yaml` tools currently ship the older 2-hint subset (`readOnlyHint` + `destructiveHint` only); when touching that file, extend with `idempotentHint` and `openWorldHint: false` per the patterns above.
 
 Tool response payloads must stay under 25,000 tokens — trim in the backend handler, not the schema.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,16 @@ Each skill file must have YAML frontmatter with `name` and `description`.
 1. Update the test fixtures in `scripts/validate.test.js` (`setupValidProject` function) if your addition exercises a validation path not already covered
 2. Run `pnpm run validate && pnpm test` to confirm
 
+### Documentation Parity
+
+`pnpm run validate` checks schemas and manifests, not prose — a tool or skill that ships without its documentation row passes CI silently. When your change adds, renames, or removes any of the following, update every listed surface in the same PR:
+
+| Change | Surfaces to update |
+|--------|--------------------|
+| Tool (`tools/*.yaml`) | README `## Tools` table **and its tool count**, `AGENTS.md` domain summary, `CLAUDE.md` tool inventory |
+| Skill (`skills/*/`) | README `## Skills` table, `AGENTS.md` skill routing table, `CLAUDE.md` skills table |
+| Slash command (`commands/`) | README `## Commands` table, `CLAUDE.md` slash commands table |
+
 ### Validation
 
 Before submitting, ensure both pass:
@@ -156,8 +166,9 @@ By signing off, you agree to the [Developer Certificate of Origin](https://devel
 1. Create a branch from `main` following the naming convention above
 2. Make your changes in focused, logical commits (signed off with `-s`)
 3. Run `pnpm run validate && pnpm test` locally
-4. Open a PR against `main` using the PR template
-5. Wait for CI to pass and a maintainer to review
+4. If you added, renamed, or removed a tool, skill, or command, update the surfaces in [Documentation Parity](#documentation-parity)
+5. Open a PR against `main` using the PR template
+6. Wait for CI to pass and a maintainer to review
 
 ## Review Expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Each skill file must have YAML frontmatter with `name` and `description`.
 
 ### Documentation Parity
 
-`pnpm run validate` checks schemas and manifests, not prose — a tool or skill that ships without its documentation row passes CI silently. When your change adds, renames, or removes any of the following, update every listed surface in the same PR:
+`pnpm run validate` enforces one slice of this: every tool name in `tools/*.yaml` must appear (backtick-wrapped) in `README.md`, and the README's "N MCP tools" count must match. Everything else in the table below is prose the validator cannot check — a skill or command that ships without its documentation row passes CI silently. When your change adds, renames, or removes any of the following, update every listed surface in the same PR:
 
 | Change | Surfaces to update |
 |--------|--------------------|

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Every step above uses only what this plugin ships: the app tools (`uploadAppToSt
 
 ## Tools
 
-29 MCP tools across 5 domains.
+30 MCP tools across 5 domains.
 
 ### Devices
 
@@ -456,6 +456,7 @@ Every step above uses only what this plugin ships: the app tools (`uploadAppToSt
 | Tool | Description |
 |------|-------------|
 | `getCredential` | Return the authenticated user's username, API key, and portal URL — backs `/automate:setup` |
+| `getOrgSettings` | Return your organization's feature flags and preferences (e.g. live remediation) — read up front by `create-test-run` and `monitor-test-run` |
 
 ## Skills
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Kobiton MCP Tools — Examples
 
-A guide to every tool available in the Kobiton MCP server, organized by domain. Each tool includes a description and natural-language prompt examples you can use directly in Claude Code.
+Worked examples for the most common Kobiton MCP tools, organized by domain. Each tool includes a description and natural-language prompt examples you can use directly in Claude Code. For the complete tool inventory, see the [README Tools section](../README.md#tools).
 
 ---
 

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -117,6 +117,7 @@ export function validateProject(rootDir) {
   }
 
   // Validate tool YAML files (auto-discovered from tools/)
+  const toolNames = []
   const toolsDir = join(rootDir, 'tools')
   if (!existsSync(toolsDir)) {
     fail('tools/ directory does not exist')
@@ -140,6 +141,9 @@ export function validateProject(rootDir) {
           if (!tool.name) {
             fail(`tools/${file} has tool without "name"`)
           }
+          else {
+            toolNames.push(tool.name)
+          }
           if (!tool.description) {
             fail(`tools/${file} tool "${tool.name}" missing "description"`)
           }
@@ -152,6 +156,29 @@ export function validateProject(rootDir) {
       catch (e) {
         fail(`tools/${file} is not valid YAML: ${e.message}`)
       }
+    }
+  }
+
+  // Validate README documents every tool (see CONTRIBUTING § Documentation Parity)
+  const readmePath = join(rootDir, 'README.md')
+  if (!existsSync(readmePath)) {
+    fail('README.md does not exist')
+  }
+  else if (toolNames.length > 0) {
+    const readme = readFileSync(readmePath, 'utf8')
+
+    const missing = toolNames.filter((name) => !readme.includes(`\`${name}\``))
+    for (const name of missing) {
+      fail(`README.md does not mention \`${name}\` — add it to the Tools table (see CONTRIBUTING § Documentation Parity)`)
+    }
+
+    const countMatch = readme.match(/(\d+) MCP tools/)
+    if (countMatch && Number(countMatch[1]) !== toolNames.length) {
+      fail(`README.md says "${countMatch[0]}" but tools/*.yaml define ${toolNames.length}`)
+    }
+
+    if (missing.length === 0 && (!countMatch || Number(countMatch[1]) === toolNames.length)) {
+      pass(`README.md documents all ${toolNames.length} tools`)
     }
   }
 

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -87,6 +87,16 @@ function setupValidProject(dir) {
     ].join('\n'))
   }
 
+  writeFileSync(join(dir, 'README.md'), [
+    '## Tools',
+    '',
+    '4 MCP tools across 4 domains.',
+    '',
+    '| Tool | Description |',
+    '|------|-------------|',
+    '| `testTool` | A test tool |',
+  ].join('\n'))
+
   mkdirSync(join(dir, 'skills/run-automation-suite'), {recursive: true})
   writeFileSync(join(dir, 'skills/run-automation-suite/SKILL.md'), [
     '---',
@@ -173,6 +183,56 @@ describe('validateProject', () => {
     ].join('\n'))
     const {errors} = validateProject(tmpDir)
     expect(errors).toContainEqual(expect.stringContaining('missing "inputSchema"'))
+  })
+
+  it('fails when README.md is missing', () => {
+    setupValidProject(tmpDir)
+    rmSync(join(tmpDir, 'README.md'))
+    const {errors} = validateProject(tmpDir)
+    expect(errors).toContainEqual(expect.stringContaining('README.md does not exist'))
+  })
+
+  it('fails when README does not mention a tool', () => {
+    setupValidProject(tmpDir)
+    writeFileSync(join(tmpDir, 'tools/devices.yaml'), [
+      'tools:',
+      '  - name: undocumentedTool',
+      '    description: A test tool',
+      '    inputSchema:',
+      '      type: object',
+    ].join('\n'))
+    const {errors} = validateProject(tmpDir)
+    expect(errors).toContainEqual(expect.stringContaining('README.md does not mention `undocumentedTool`'))
+  })
+
+  it('fails when the README tool count is stale', () => {
+    setupValidProject(tmpDir)
+    writeFileSync(join(tmpDir, 'README.md'), [
+      '## Tools',
+      '',
+      '3 MCP tools across 4 domains.',
+      '',
+      '| `testTool` | A test tool |',
+    ].join('\n'))
+    const {errors} = validateProject(tmpDir)
+    expect(errors).toContainEqual(expect.stringContaining('README.md says "3 MCP tools" but tools/*.yaml define 4'))
+  })
+
+  it('does not match a tool name that is a prefix of a documented tool', () => {
+    setupValidProject(tmpDir)
+    writeFileSync(join(tmpDir, 'tools/devices.yaml'), [
+      'tools:',
+      '  - name: testTool',
+      '    description: A test tool',
+      '    inputSchema:',
+      '      type: object',
+      '  - name: test',
+      '    description: A prefix-named tool the README does not document',
+      '    inputSchema:',
+      '      type: object',
+    ].join('\n'))
+    const {errors} = validateProject(tmpDir)
+    expect(errors).toContainEqual(expect.stringContaining('README.md does not mention `test`'))
   })
 
   it('fails when skill is missing frontmatter', () => {

--- a/scripts/validate.test.js
+++ b/scripts/validate.test.js
@@ -231,8 +231,16 @@ describe('validateProject', () => {
       '    inputSchema:',
       '      type: object',
     ].join('\n'))
+    writeFileSync(join(tmpDir, 'README.md'), [
+      '## Tools',
+      '',
+      '5 MCP tools across 4 domains.',
+      '',
+      '| `testTool` | A test tool |',
+    ].join('\n'))
     const {errors} = validateProject(tmpDir)
     expect(errors).toContainEqual(expect.stringContaining('README.md does not mention `test`'))
+    expect(errors).not.toContainEqual(expect.stringContaining('MCP tools'))
   })
 
   it('fails when skill is missing frontmatter', () => {


### PR DESCRIPTION
## Summary

`getOrgSettings` shipped in `tools/user.yaml` but never made it into the published docs — the README Tools table, the `AGENTS.md` domain summary, and the `CLAUDE.md` tool inventory all still listed only `getCredential` for the user domain, so a reader could not discover the tool. This PR closes that gap, adds a contributing-guide rule for doc surfaces, and turns the tool/README slice of that rule into a CI gate in `validate.js`.

## Changes

**Docs**
- **README**: add `getOrgSettings` to the Account table; tool count 29 → 30
- **AGENTS.md**: rename the *Setup* bullet to *Account* (matching the README domain name) and list `getOrgSettings` alongside `getCredential`
- **CLAUDE.md**: add `getOrgSettings` to the tool inventory; drop `user.yaml` from the older-2-hint-shape notes — both its tools now carry the full annotation block, only `test-management.yaml` remains on the old shape
- **docs/examples.md**: stop claiming it covers "every tool" (it documents the common ones) and link the README for the full inventory
- **CONTRIBUTING**: new *Documentation Parity* section — a table mapping each change type (tool / skill / command) to the doc surfaces that must be updated in the same PR, with a pointer from the Pull Request Process checklist

**CI gate**
- **scripts/validate.js**: every tool name in `tools/*.yaml` must appear backtick-wrapped in `README.md` (backtick matching so `getApp` doesn't false-match inside `getAppParsingStatus`), and the README's "N MCP tools" count must equal the YAML total. Either drift now fails `pnpm run validate`, which CI runs on every push/PR — this is the check that would have caught `getOrgSettings` shipping undocumented. Skills and commands remain prose-only surfaces covered by the CONTRIBUTING table.
- **scripts/validate.test.js**: fixture gains a minimal README; 4 new tests cover the missing-README, undocumented-tool, stale-count, and prefix-name paths

## Testing

- `pnpm run validate` — all checks pass, including the new `README.md documents all 30 tools`
- `pnpm test` — 193/193 pass (189 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)