### PR TITLE
docs: full restricted-session policy for run-interactive-session adb-shell (KOB-54475, 1.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "automate",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
       "author": {
         "name": "Kobiton Inc.",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.codex/.codex-plugin/plugin.json
+++ b/.codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/.codex/skills/run-interactive-session/SKILL.md
+++ b/.codex/skills/run-interactive-session/SKILL.md
@@ -225,26 +225,62 @@ This terminates the Kobiton-side session and frees the device. The local artifac
 
 ### adb-shell commands (Android only)
 
-`device adb-shell` forwards everything after it to `adb shell <...>` on the device. Two failure modes account for most AI-agent mistakes - read these before composing a command.
+`device adb-shell` forwards everything after it to `adb shell <...>` on the device. Three failure modes account for most AI-agent mistakes - read these before composing a command.
+
+**Restricted sessions (public cloud and trial devices).** On Kobiton public cloud devices and for trial users, every invocation is checked against a deny-by-default whitelist before it reaches the device. Dedicated devices (private cloud / on-premise) are unrestricted; everything in this block applies only to restricted sessions. The interactive shell is unavailable on restricted sessions - every invocation must name a command.
+
+Rejected on restricted sessions:
+
+- Any command not in the whitelist below, and command lines longer than 1024 characters.
+- Control characters, and these shell metacharacters anywhere in the input: `` & ; | $ ` ( ) > < \ " ' * ? ~ { } # ! `` - so no pipes, redirection, command or variable substitution, backgrounding, globbing, or **quoting**. Arguments may not contain whitespace.
+
+Whitelisted commands, by category:
+
+| Category | Commands |
+|----------|----------|
+| Device information | `getprop`, `dumpsys`, `df`, `free` |
+| Diagnostics | `logcat`, `ps`, `top`, `netstat`, `printenv`, `uptime`, `id`, `whoami`, `date` (flags only) |
+| Applications | `pm`, `am`, `monkey` (`pm install` may name an APK inside the allowed directories below) |
+| Text tools | `grep`, `egrep`, `fgrep`, `head`, `tail`, `wc`, `sort`, `uniq`, `nl`, `cut` - they read files, not stdin (pipes are rejected), and pattern arguments are limited to letters, digits, dot, underscore, hyphen |
+| File inspection | `ls`, `cat`, `stat`, `du`, `md5sum`, `sha1sum` |
+| Screen and input | `screencap`, `input` |
+| Settings | `settings` - one key only, see below |
+
+File-path arguments must stay inside `/sdcard/Download/`, `/sdcard/Documents/`, or `/data/local/tmp/`, plus the individually allowed read-only file `/proc/version`; paths containing `..` are rejected. To list a directory outside that allowlist, use `$KOBITON_BIN file list <path>` instead of `adb-shell ls`. The same directories bound `file push` / `file pull`.
+
+Settings: only `settings get secure enabled_accessibility_services` and `settings put secure enabled_accessibility_services <value>` are permitted. Every other settings namespace, key, and subcommand (including `list` and `delete`) is rejected.
+
+A rejected invocation prints one of these messages on stdout and - gotcha - **exits 0**, so check the first line of output rather than `$?`:
+
+- `Input contains a forbidden character: '<c>'.`
+- `Command is not on the whitelist: '<cmd>'.`
+- `Argument is not permitted for '<cmd>': '<arg>'.`
+- `Only get/put of secure enabled_accessibility_services is permitted for 'settings'.` (the settings rule has its own message)
+
+The whitelist evolves with CLI releases; `$KOBITON_BIN device adb-shell --help` carries the full current policy - trust it over this snapshot.
 
 **Quoting rules.** The local shell parses pipes, redirects, globs, and variable expansion *before* the wrapper sees them. Anything you wrap in quotes survives to the device's shell; anything outside is interpreted on your laptop.
 
-- **Plain command, no shell metacharacters** - pass args separately:
+- **Plain command, no shell metacharacters** - pass args separately (works on restricted and unrestricted sessions alike; `/sdcard/Download/` is inside the restricted path allowlist):
 
       $KOBITON_BIN device adb-shell ls -la /sdcard/Download/
       $KOBITON_BIN device adb-shell getprop ro.build.version.release
 
-- **Restricted shell (the common policy on cloud devices)** - the CLI validates the remote command and rejects shell metacharacters outright (`Input contains a forbidden character: '|'`), and blocks some argument shapes entirely (e.g. a URL passed to `am`). Do not pipe, chain, or redirect on the device. The pattern that works everywhere: run the bare command, redirect its output to a local artifact file, filter locally:
-
-      $KOBITON_BIN device adb-shell dumpsys window > .kobiton/sessions/<session-id>/window.txt
-      grep -m3 -E 'mCurrentFocus|mFocusedApp' .kobiton/sessions/<session-id>/window.txt
-
-- **On-device pipes only with full shell access** (an org-level setting - assume restricted until a piped command succeeds): wrap the entire remote command in one quoted string so it runs on the device's shell, not your local shell:
+- **Pipes, redirects, globs, `&&`, `$VAR`, or quotes inside the command** - **unrestricted (dedicated) devices only**: wrap the entire remote command in one quoted string so it runs on the device's shell, not your local shell:
 
       $KOBITON_BIN device adb-shell "dumpsys window | grep mCurrentFocus"
       $KOBITON_BIN device adb-shell 'pm list packages -3 | wc -l'
+      $KOBITON_BIN device adb-shell "logcat -d -t 200 > /sdcard/log.txt"
 
-  If it comes back with `Input contains a forbidden character`, the device shell is restricted - fall back to the bare-command + local-filter pattern above.
+  On a **restricted session** this form is rejected outright - the quotes and the metacharacters inside them are all forbidden characters, so there is no on-device composition form at all. Compose locally instead (next bullet).
+
+- **Restricted sessions: compose locally.** Run the bare whitelisted command, bound its output, redirect *locally* into the session artifact directory, then filter the file locally:
+
+      $KOBITON_BIN device adb-shell dumpsys window \
+        > .kobiton/sessions/<session-id>/window-$(date +%s).txt
+      grep mCurrentFocus .kobiton/sessions/<session-id>/window-*.txt
+
+  On unrestricted devices prefer the quoted on-device form - filtering locally on the full output is slower and can overflow the 25k-token MCP limit if it isn't routed through an artifact file. On restricted sessions the local route is the only one: always bound the command (`-d -t N`, `-n 1`) and go through an artifact file, never paste raw output to chat.
 
 **Platform guard.** `adb` is Android-only. If the active session targets iOS, do **not** call `device adb-shell`. Refuse and reach for the WebDriver equivalent (`wd post execute '{"script":"mobile: ..."}'`) or a different inspection path.
 
@@ -254,34 +290,38 @@ This terminates the Kobiton-side session and frees the device. The local artifac
     # stock macOS has no `timeout` - use the perl-alarm equivalent (exit 142 = SIGALRM, same meaning):
     perl -e 'alarm shift; exec @ARGV' 45 ~/.kobiton/bin/kobiton device log > .kobiton/sessions/<session-id>/device-log.txt
 
-| Intent | Command |
-|--------|---------|
-| Get OS / build property | `$KOBITON_BIN device adb-shell getprop <key>` |
-| Get screen resolution | `$KOBITON_BIN device adb-shell wm size` |
-| Get foreground app/activity | `$KOBITON_BIN device adb-shell dumpsys window > <local-file>`, then grep `mCurrentFocus` locally (on-device pipe needs full shell access) |
-| Open a URL (Android Chrome) | UI-driven (restricted shell rejects `am start ... -d <url>`): launch Chrome via `monkey -p com.android.chrome -c android.intent.category.LAUNCHER 1`, then `wd post element '{"using":"id","value":"com.android.chrome:id/url_bar"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>"}'` → `input keyevent 66` |
-| Open a URL (iOS Safari) | `wd post execute '{"script":"mobile: launchApp","args":[{"bundleId":"com.apple.mobilesafari"}]}'` → `wd post element '{"using":"accessibility id","value":"TabBarItemTitle"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>\n"}'` — the trailing `\n` submits (iOS has no keyevent); `click` requires a body, `'{}'` works |
-| List running processes | `$KOBITON_BIN device adb-shell ps -A` |
-| List user-installed packages | `$KOBITON_BIN device adb-shell pm list packages -3` |
-| Find APK path of a package | `$KOBITON_BIN device adb-shell pm path <pkg>` |
-| Launch app by package | `$KOBITON_BIN device adb-shell monkey -p <pkg> -c android.intent.category.LAUNCHER 1` |
-| Force-stop app | `$KOBITON_BIN device adb-shell am force-stop <pkg>` |
-| Clear app data | `$KOBITON_BIN device adb-shell pm clear <pkg>` |
-| Battery level + charging state | `$KOBITON_BIN device adb-shell dumpsys battery` |
-| Memory snapshot for a package | `$KOBITON_BIN device adb-shell dumpsys meminfo <pkg>` |
-| Storage free on /sdcard | `$KOBITON_BIN device adb-shell df -h /sdcard` |
-| Press hardware key (home=3, back=4, power=26) | `$KOBITON_BIN device adb-shell input keyevent <code>` |
-| Type text into focused field | `$KOBITON_BIN device adb-shell input text "<text>"` |
-| Tap at coordinates | `$KOBITON_BIN device adb-shell input tap <x> <y>` |
-| Swipe (ms = duration) | `$KOBITON_BIN device adb-shell input swipe <x1> <y1> <x2> <y2> <ms>` |
-| Read recent logs (Android only) | `$KOBITON_BIN device adb-shell logcat -d -t 500 > <local-file>` — on iOS use `device log` (see "Device logs on iOS" above) |
-| Read system setting | `$KOBITON_BIN device adb-shell settings get system <key>` |
-| Write system setting | `$KOBITON_BIN device adb-shell settings put system <key> <value>` |
-| Read file content | `$KOBITON_BIN device adb-shell cat <path>` |
-| List directory | `$KOBITON_BIN device adb-shell ls -la <path>` |
-| Current IME | `$KOBITON_BIN device adb-shell dumpsys input_method > <local-file>`, then grep `mCurId` locally |
+The **Restricted** column says what changes on a restricted session; `ok` means the command runs as written.
 
-**Big-output commands.** `dumpsys`, `logcat`, `pm list -f`, and full process dumps can blow past the 25k-token MCP limit. For these, redirect to an artifact file first, then read/grep only what you need (this doubles as the restricted-shell-safe filtering pattern):
+| Intent | Command | Restricted |
+|--------|---------|------------|
+| Get OS / build property | `$KOBITON_BIN device adb-shell getprop <key>` | ok |
+| Get screen resolution | `$KOBITON_BIN device adb-shell wm size` | rejected (`wm` not whitelisted) - use `$KOBITON_BIN wd get window/rect` instead |
+| Get foreground app/activity | `$KOBITON_BIN device adb-shell "dumpsys window \| grep mCurrentFocus"` | quoted pipe rejected - run bare `dumpsys window`, filter locally |
+| Open a URL (Android Chrome) | UI-driven: launch Chrome via `monkey -p com.android.chrome -c android.intent.category.LAUNCHER 1`, then `wd post element '{"using":"id","value":"com.android.chrome:id/url_bar"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>"}'` → `input keyevent 66` | this recipe IS the restricted path - a URL argument to `am start` is rejected (`Argument is not permitted for 'am'`); on unrestricted devices `am start -a android.intent.action.VIEW -d <url>` also works |
+| Open a URL (iOS Safari) | `wd post execute '{"script":"mobile: launchApp","args":[{"bundleId":"com.apple.mobilesafari"}]}'` → `wd post element '{"using":"accessibility id","value":"TabBarItemTitle"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>\n"}'` — the trailing `\n` submits (iOS has no keyevent); `click` requires a body, `'{}'` works | n/a - WebDriver path, not adb-shell |
+| List running processes | `$KOBITON_BIN device adb-shell ps -A` | ok |
+| List user-installed packages | `$KOBITON_BIN device adb-shell pm list packages -3` | ok |
+| Find APK path of a package | `$KOBITON_BIN device adb-shell pm path <pkg>` | ok |
+| Launch app by package | `$KOBITON_BIN device adb-shell monkey -p <pkg> -c android.intent.category.LAUNCHER 1` | ok |
+| Force-stop app | `$KOBITON_BIN device adb-shell am force-stop <pkg>` | ok |
+| Clear app data | `$KOBITON_BIN device adb-shell pm clear <pkg>` | ok |
+| Battery level + charging state | `$KOBITON_BIN device adb-shell dumpsys battery` | ok |
+| Memory snapshot for a package | `$KOBITON_BIN device adb-shell dumpsys meminfo <pkg>` | ok |
+| Storage free on /sdcard | `$KOBITON_BIN device adb-shell df -h /sdcard` | ok |
+| Press hardware key (home=3, back=4, power=26) | `$KOBITON_BIN device adb-shell input keyevent <code>` | ok |
+| Type text into focused field | `$KOBITON_BIN device adb-shell input text "<text>"` | quotes/whitespace rejected - a single token works (`%s` encodes a space); for real text entry prefer `wd post element/<id>/value` |
+| Tap at coordinates | `$KOBITON_BIN device adb-shell input tap <x> <y>` | ok |
+| Swipe (ms = duration) | `$KOBITON_BIN device adb-shell input swipe <x1> <y1> <x2> <y2> <ms>` | ok |
+| Read recent logs (Android only) | `$KOBITON_BIN device adb-shell logcat -d -t 500 > <local-file>` — on iOS use `device log` (see "Device logs on iOS" above) | ok (no quotes needed - the args carry no metacharacters; the redirect is local) |
+| Screenshot via shell | `$KOBITON_BIN device adb-shell screencap -p /sdcard/Download/shot.png` | ok - retrieve with `file pull` (or use `device screen` directly) |
+| Read system setting | `$KOBITON_BIN device adb-shell settings get system <key>` | rejected - only the `secure enabled_accessibility_services` key is readable/writable |
+| Write system setting | `$KOBITON_BIN device adb-shell settings put system <key> <value>` | rejected - same single-key rule |
+| Read/write enabled accessibility services | `$KOBITON_BIN device adb-shell settings get secure enabled_accessibility_services` / `... put secure enabled_accessibility_services <value>` | ok - the one permitted settings key (`<value>` is colon-separated components, or `null` to clear) |
+| Read file content | `$KOBITON_BIN device adb-shell cat <path>` | path allowlist applies (allowed dirs + `/proc/version`) |
+| List directory | `$KOBITON_BIN device adb-shell ls -la <path>` | path allowlist applies - outside it, use `$KOBITON_BIN file list <path>` |
+| Current IME | `$KOBITON_BIN device adb-shell "dumpsys input_method \| grep mCurId"` | quoted pipe rejected - run bare `dumpsys input_method`, filter locally |
+
+**Big-output commands.** `dumpsys`, `logcat`, `pm list -f`, and full process dumps can blow past the 25k-token MCP limit. For these, redirect to an artifact file first, then read/grep only what you need (the redirect is your *local* shell's, so this exact pattern also works on restricted sessions - it is the same local-composition idiom from the quoting rules):
 
     $KOBITON_BIN device adb-shell logcat -d -t 1000 \
       > .kobiton/sessions/<session-id>/logcat-$(date +%s).txt
@@ -309,7 +349,7 @@ These commands require an active session. Run `$KOBITON_BIN <command> --help` to
 | Domain | Command | What it does |
 |--------|---------|-------------|
 | Device | `$KOBITON_BIN device screen` | Capture device screen as jpg |
-| Device | `$KOBITON_BIN device forward <local> <remote>` | Forward local port to device |
+| Device | `$KOBITON_BIN device forward <local> <remote>` | Forward local port to device. Runs in the foreground until interrupted and holds the local port for the lifetime of the forward - launch with `run_in_background: true` and kill explicitly, like the long-running adb-shell commands above |
 | Device | `$KOBITON_BIN device ps` | List processes on device |
 | File | `$KOBITON_BIN file list <path>` | List files on device |
 | File | `$KOBITON_BIN file push <local> <remote>` | Push file to device |

--- a/.codex/skills/run-interactive-session/references/response-shapes.md
+++ b/.codex/skills/run-interactive-session/references/response-shapes.md
@@ -27,9 +27,10 @@ Most WebDriver endpoints return a JSON envelope `{"value": <result>}`. A few com
 
 | Command | Response on stdout | How to read |
 |---|---|---|
-| `device adb-shell <cmd>` | Raw stdout from the on-device shell. Shape depends on `<cmd>` - KV pairs (`dumpsys battery`), single line (`getprop`), multi-line table (`pm list`, `ps`), or free text (`logcat`) | (a) For single-value extractions, `grep` or `awk` the line. (b) For multi-line output, save to artifact then parse. (c) **Gotcha:** exit code 0 does NOT mean the inner command succeeded - adb returns 0 as long as it could deliver the command; check stderr or look for error strings in stdout. |
+| `device adb-shell <cmd>` | Raw stdout from the on-device shell. Shape depends on `<cmd>` - KV pairs (`dumpsys battery`), single line (`getprop`), multi-line table (`pm list`, `ps`), or free text (`logcat`) | (a) For single-value extractions, `grep` or `awk` the line. (b) For multi-line output, save to artifact then parse. (c) **Gotcha:** exit code 0 does NOT mean the inner command succeeded - adb returns 0 as long as it could deliver the command; check stderr or look for error strings in stdout. (d) On restricted sessions (public cloud / trial devices) a **whitelist rejection also lands on stdout at exit 0** - string-match the first line against `Input contains a forbidden character:`, `Command is not on the whitelist:`, `Argument is not permitted for`, and `Only get/put of secure enabled_accessibility_services is permitted` before trusting empty or short output (see the SKILL's Restricted sessions block). |
 | `device screen` | JPEG image bytes - check `--help` for output flag (e.g., `--out`) | Redirect or use the documented output flag |
-| `device forward`, `device ps`, `file list` | Plain text on stdout | Read directly |
+| `device forward` | `Listening on <addr>.` then blocks - the command runs in the foreground for the lifetime of the forward and holds the local port | A non-returning invocation is normal, not a hang; launch with `run_in_background: true` and kill explicitly to release the port |
+| `device ps`, `file list` | Plain text on stdout | Read directly |
 | `file push`, `file pull` | Text confirmation; non-zero exit on failure | Surface failures by exit code |
 | `app run <app-id>` | Text confirmation; the app launches on the device | Continue interacting after launch |
 | `test run` | Streaming test-runner output | Run with `run_in_background: true`; parse the final summary block |

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "automate",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
       "author": {
         "name": "Kobiton Inc.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "automate",
   "displayName": "automate",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "author": {
     "name": "Kobiton Inc.",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ For exploratory testing or repro work (not running a pre-written script):
 
 Detailed step-by-step instructions live in `skills/run-interactive-session/SKILL.md`. Response shapes for the WebDriver layer are documented at `skills/run-interactive-session/references/response-shapes.md`.
 
+Note for `adb-shell` work: on public cloud and trial devices the shell is **restricted** — a deny-by-default command whitelist, a forbidden-character set that includes pipes and quotes (so no on-device composition; run the bare command and filter locally), a file-path allowlist, and a single permitted `settings` key. Rejections print on stdout at exit 0. The SKILL's "Restricted sessions" block carries the policy; `kobiton device adb-shell --help` carries the current authoritative version. Dedicated (private cloud / on-premise) devices are unrestricted.
+
 ## When the user asks to drive a device from a natural-language intent
 
 **Pick this skill** for agent-driven flows the user describes in plain language ("open YouTube and play the first world cup video", "log in then enable Bluetooth, then go home") — it auto-pilots from observation to action without a human in the loop on each step, and the result is a saveable test case. It complements (does NOT replace) `run-interactive-session`: that one is for human-driven exploration via the CLI session type; this one uses the automation session type via direct Appium HTTP. (Tool names below are the Kobiton MCP tools' bare names — the host resolves the registered prefix.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.10.1 - 2026-08-12
+
+### Fixed: adb-shell guidance now carries the full restricted-session policy
+
+1.10.0 introduced basic restricted-shell guidance (bare-command + local-filter, the forbidden-character rejection). This release replaces it with the complete policy for restricted sessions (public cloud and trial devices): the deny-by-default command whitelist by category, the full forbidden-character set (pipes **and quotes** — there is no on-device composition form at all), the file-path allowlist, the single permitted `settings` key (`secure enabled_accessibility_services`), the four rejection message shapes — incl. the settings-specific message, verified live on restricted devices — with the exit-0 gotcha (rejections print on stdout and exit 0, so scripts must string-match the first line rather than `$?`), and a pointer to `kobiton device adb-shell --help` as the always-current authority.
+
+The quoted on-device form is scoped to dedicated (unrestricted) devices; the command table gains a **Restricted** column covering every row — including `ls`/`cat` path limits, the `input text` single-token limit, `wm size` → `wd get window/rect`, a new `screencap` row, and the accessibility-services settings key. `device forward` is documented as a foreground command that holds the local port until killed, and `references/response-shapes.md` and `AGENTS.md` carry the same facts so no host is left with the old guidance.
+
+The whitelist entries describe the current deviceConnect sanitizer; on environments running an older deviceConnect a few expanded entries (`cat /proc/version`, `screencap`, `input`, the settings key) may still be rejected — the `--help` pointer is the always-current authority.
+
+No binary change ships with this release: the CLI is downloaded per the 1.10.0 pin model, and the pinned build already carries the file-transfer status fix this branch originally bundled.
+
 ## 1.10.0 - 2026-08-11
 
 ### Changed: the CLI binary is downloaded on install, no longer committed to the repo

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kobiton-automate",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Connect to Kobiton mobile testing platform - manage devices, run automation suites, and view test results",
   "contextFileName": "AGENTS.md",
   "mcpServers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automate",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "private": true,
   "description": "Kobiton plugin manifests, tool schemas, and skills for AI coding assistants",

--- a/skills/run-interactive-session/SKILL.md
+++ b/skills/run-interactive-session/SKILL.md
@@ -225,26 +225,62 @@ This terminates the Kobiton-side session and frees the device. The local artifac
 
 ### adb-shell commands (Android only)
 
-`device adb-shell` forwards everything after it to `adb shell <...>` on the device. Two failure modes account for most AI-agent mistakes - read these before composing a command.
+`device adb-shell` forwards everything after it to `adb shell <...>` on the device. Three failure modes account for most AI-agent mistakes - read these before composing a command.
+
+**Restricted sessions (public cloud and trial devices).** On Kobiton public cloud devices and for trial users, every invocation is checked against a deny-by-default whitelist before it reaches the device. Dedicated devices (private cloud / on-premise) are unrestricted; everything in this block applies only to restricted sessions. The interactive shell is unavailable on restricted sessions - every invocation must name a command.
+
+Rejected on restricted sessions:
+
+- Any command not in the whitelist below, and command lines longer than 1024 characters.
+- Control characters, and these shell metacharacters anywhere in the input: `` & ; | $ ` ( ) > < \ " ' * ? ~ { } # ! `` - so no pipes, redirection, command or variable substitution, backgrounding, globbing, or **quoting**. Arguments may not contain whitespace.
+
+Whitelisted commands, by category:
+
+| Category | Commands |
+|----------|----------|
+| Device information | `getprop`, `dumpsys`, `df`, `free` |
+| Diagnostics | `logcat`, `ps`, `top`, `netstat`, `printenv`, `uptime`, `id`, `whoami`, `date` (flags only) |
+| Applications | `pm`, `am`, `monkey` (`pm install` may name an APK inside the allowed directories below) |
+| Text tools | `grep`, `egrep`, `fgrep`, `head`, `tail`, `wc`, `sort`, `uniq`, `nl`, `cut` - they read files, not stdin (pipes are rejected), and pattern arguments are limited to letters, digits, dot, underscore, hyphen |
+| File inspection | `ls`, `cat`, `stat`, `du`, `md5sum`, `sha1sum` |
+| Screen and input | `screencap`, `input` |
+| Settings | `settings` - one key only, see below |
+
+File-path arguments must stay inside `/sdcard/Download/`, `/sdcard/Documents/`, or `/data/local/tmp/`, plus the individually allowed read-only file `/proc/version`; paths containing `..` are rejected. To list a directory outside that allowlist, use `$KOBITON_BIN file list <path>` instead of `adb-shell ls`. The same directories bound `file push` / `file pull`.
+
+Settings: only `settings get secure enabled_accessibility_services` and `settings put secure enabled_accessibility_services <value>` are permitted. Every other settings namespace, key, and subcommand (including `list` and `delete`) is rejected.
+
+A rejected invocation prints one of these messages on stdout and - gotcha - **exits 0**, so check the first line of output rather than `$?`:
+
+- `Input contains a forbidden character: '<c>'.`
+- `Command is not on the whitelist: '<cmd>'.`
+- `Argument is not permitted for '<cmd>': '<arg>'.`
+- `Only get/put of secure enabled_accessibility_services is permitted for 'settings'.` (the settings rule has its own message)
+
+The whitelist evolves with CLI releases; `$KOBITON_BIN device adb-shell --help` carries the full current policy - trust it over this snapshot.
 
 **Quoting rules.** The local shell parses pipes, redirects, globs, and variable expansion *before* the wrapper sees them. Anything you wrap in quotes survives to the device's shell; anything outside is interpreted on your laptop.
 
-- **Plain command, no shell metacharacters** - pass args separately:
+- **Plain command, no shell metacharacters** - pass args separately (works on restricted and unrestricted sessions alike; `/sdcard/Download/` is inside the restricted path allowlist):
 
       $KOBITON_BIN device adb-shell ls -la /sdcard/Download/
       $KOBITON_BIN device adb-shell getprop ro.build.version.release
 
-- **Restricted shell (the common policy on cloud devices)** - the CLI validates the remote command and rejects shell metacharacters outright (`Input contains a forbidden character: '|'`), and blocks some argument shapes entirely (e.g. a URL passed to `am`). Do not pipe, chain, or redirect on the device. The pattern that works everywhere: run the bare command, redirect its output to a local artifact file, filter locally:
-
-      $KOBITON_BIN device adb-shell dumpsys window > .kobiton/sessions/<session-id>/window.txt
-      grep -m3 -E 'mCurrentFocus|mFocusedApp' .kobiton/sessions/<session-id>/window.txt
-
-- **On-device pipes only with full shell access** (an org-level setting - assume restricted until a piped command succeeds): wrap the entire remote command in one quoted string so it runs on the device's shell, not your local shell:
+- **Pipes, redirects, globs, `&&`, `$VAR`, or quotes inside the command** - **unrestricted (dedicated) devices only**: wrap the entire remote command in one quoted string so it runs on the device's shell, not your local shell:
 
       $KOBITON_BIN device adb-shell "dumpsys window | grep mCurrentFocus"
       $KOBITON_BIN device adb-shell 'pm list packages -3 | wc -l'
+      $KOBITON_BIN device adb-shell "logcat -d -t 200 > /sdcard/log.txt"
 
-  If it comes back with `Input contains a forbidden character`, the device shell is restricted - fall back to the bare-command + local-filter pattern above.
+  On a **restricted session** this form is rejected outright - the quotes and the metacharacters inside them are all forbidden characters, so there is no on-device composition form at all. Compose locally instead (next bullet).
+
+- **Restricted sessions: compose locally.** Run the bare whitelisted command, bound its output, redirect *locally* into the session artifact directory, then filter the file locally:
+
+      $KOBITON_BIN device adb-shell dumpsys window \
+        > .kobiton/sessions/<session-id>/window-$(date +%s).txt
+      grep mCurrentFocus .kobiton/sessions/<session-id>/window-*.txt
+
+  On unrestricted devices prefer the quoted on-device form - filtering locally on the full output is slower and can overflow the 25k-token MCP limit if it isn't routed through an artifact file. On restricted sessions the local route is the only one: always bound the command (`-d -t N`, `-n 1`) and go through an artifact file, never paste raw output to chat.
 
 **Platform guard.** `adb` is Android-only. If the active session targets iOS, do **not** call `device adb-shell`. Refuse and reach for the WebDriver equivalent (`wd post execute '{"script":"mobile: ..."}'`) or a different inspection path.
 
@@ -254,34 +290,38 @@ This terminates the Kobiton-side session and frees the device. The local artifac
     # stock macOS has no `timeout` - use the perl-alarm equivalent (exit 142 = SIGALRM, same meaning):
     perl -e 'alarm shift; exec @ARGV' 45 ~/.kobiton/bin/kobiton device log > .kobiton/sessions/<session-id>/device-log.txt
 
-| Intent | Command |
-|--------|---------|
-| Get OS / build property | `$KOBITON_BIN device adb-shell getprop <key>` |
-| Get screen resolution | `$KOBITON_BIN device adb-shell wm size` |
-| Get foreground app/activity | `$KOBITON_BIN device adb-shell dumpsys window > <local-file>`, then grep `mCurrentFocus` locally (on-device pipe needs full shell access) |
-| Open a URL (Android Chrome) | UI-driven (restricted shell rejects `am start ... -d <url>`): launch Chrome via `monkey -p com.android.chrome -c android.intent.category.LAUNCHER 1`, then `wd post element '{"using":"id","value":"com.android.chrome:id/url_bar"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>"}'` → `input keyevent 66` |
-| Open a URL (iOS Safari) | `wd post execute '{"script":"mobile: launchApp","args":[{"bundleId":"com.apple.mobilesafari"}]}'` → `wd post element '{"using":"accessibility id","value":"TabBarItemTitle"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>\n"}'` — the trailing `\n` submits (iOS has no keyevent); `click` requires a body, `'{}'` works |
-| List running processes | `$KOBITON_BIN device adb-shell ps -A` |
-| List user-installed packages | `$KOBITON_BIN device adb-shell pm list packages -3` |
-| Find APK path of a package | `$KOBITON_BIN device adb-shell pm path <pkg>` |
-| Launch app by package | `$KOBITON_BIN device adb-shell monkey -p <pkg> -c android.intent.category.LAUNCHER 1` |
-| Force-stop app | `$KOBITON_BIN device adb-shell am force-stop <pkg>` |
-| Clear app data | `$KOBITON_BIN device adb-shell pm clear <pkg>` |
-| Battery level + charging state | `$KOBITON_BIN device adb-shell dumpsys battery` |
-| Memory snapshot for a package | `$KOBITON_BIN device adb-shell dumpsys meminfo <pkg>` |
-| Storage free on /sdcard | `$KOBITON_BIN device adb-shell df -h /sdcard` |
-| Press hardware key (home=3, back=4, power=26) | `$KOBITON_BIN device adb-shell input keyevent <code>` |
-| Type text into focused field | `$KOBITON_BIN device adb-shell input text "<text>"` |
-| Tap at coordinates | `$KOBITON_BIN device adb-shell input tap <x> <y>` |
-| Swipe (ms = duration) | `$KOBITON_BIN device adb-shell input swipe <x1> <y1> <x2> <y2> <ms>` |
-| Read recent logs (Android only) | `$KOBITON_BIN device adb-shell logcat -d -t 500 > <local-file>` — on iOS use `device log` (see "Device logs on iOS" above) |
-| Read system setting | `$KOBITON_BIN device adb-shell settings get system <key>` |
-| Write system setting | `$KOBITON_BIN device adb-shell settings put system <key> <value>` |
-| Read file content | `$KOBITON_BIN device adb-shell cat <path>` |
-| List directory | `$KOBITON_BIN device adb-shell ls -la <path>` |
-| Current IME | `$KOBITON_BIN device adb-shell dumpsys input_method > <local-file>`, then grep `mCurId` locally |
+The **Restricted** column says what changes on a restricted session; `ok` means the command runs as written.
 
-**Big-output commands.** `dumpsys`, `logcat`, `pm list -f`, and full process dumps can blow past the 25k-token MCP limit. For these, redirect to an artifact file first, then read/grep only what you need (this doubles as the restricted-shell-safe filtering pattern):
+| Intent | Command | Restricted |
+|--------|---------|------------|
+| Get OS / build property | `$KOBITON_BIN device adb-shell getprop <key>` | ok |
+| Get screen resolution | `$KOBITON_BIN device adb-shell wm size` | rejected (`wm` not whitelisted) - use `$KOBITON_BIN wd get window/rect` instead |
+| Get foreground app/activity | `$KOBITON_BIN device adb-shell "dumpsys window \| grep mCurrentFocus"` | quoted pipe rejected - run bare `dumpsys window`, filter locally |
+| Open a URL (Android Chrome) | UI-driven: launch Chrome via `monkey -p com.android.chrome -c android.intent.category.LAUNCHER 1`, then `wd post element '{"using":"id","value":"com.android.chrome:id/url_bar"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>"}'` → `input keyevent 66` | this recipe IS the restricted path - a URL argument to `am start` is rejected (`Argument is not permitted for 'am'`); on unrestricted devices `am start -a android.intent.action.VIEW -d <url>` also works |
+| Open a URL (iOS Safari) | `wd post execute '{"script":"mobile: launchApp","args":[{"bundleId":"com.apple.mobilesafari"}]}'` → `wd post element '{"using":"accessibility id","value":"TabBarItemTitle"}'` → `wd post element/<id>/click '{}'` → `wd post element/<id>/value '{"text":"<url>\n"}'` — the trailing `\n` submits (iOS has no keyevent); `click` requires a body, `'{}'` works | n/a - WebDriver path, not adb-shell |
+| List running processes | `$KOBITON_BIN device adb-shell ps -A` | ok |
+| List user-installed packages | `$KOBITON_BIN device adb-shell pm list packages -3` | ok |
+| Find APK path of a package | `$KOBITON_BIN device adb-shell pm path <pkg>` | ok |
+| Launch app by package | `$KOBITON_BIN device adb-shell monkey -p <pkg> -c android.intent.category.LAUNCHER 1` | ok |
+| Force-stop app | `$KOBITON_BIN device adb-shell am force-stop <pkg>` | ok |
+| Clear app data | `$KOBITON_BIN device adb-shell pm clear <pkg>` | ok |
+| Battery level + charging state | `$KOBITON_BIN device adb-shell dumpsys battery` | ok |
+| Memory snapshot for a package | `$KOBITON_BIN device adb-shell dumpsys meminfo <pkg>` | ok |
+| Storage free on /sdcard | `$KOBITON_BIN device adb-shell df -h /sdcard` | ok |
+| Press hardware key (home=3, back=4, power=26) | `$KOBITON_BIN device adb-shell input keyevent <code>` | ok |
+| Type text into focused field | `$KOBITON_BIN device adb-shell input text "<text>"` | quotes/whitespace rejected - a single token works (`%s` encodes a space); for real text entry prefer `wd post element/<id>/value` |
+| Tap at coordinates | `$KOBITON_BIN device adb-shell input tap <x> <y>` | ok |
+| Swipe (ms = duration) | `$KOBITON_BIN device adb-shell input swipe <x1> <y1> <x2> <y2> <ms>` | ok |
+| Read recent logs (Android only) | `$KOBITON_BIN device adb-shell logcat -d -t 500 > <local-file>` — on iOS use `device log` (see "Device logs on iOS" above) | ok (no quotes needed - the args carry no metacharacters; the redirect is local) |
+| Screenshot via shell | `$KOBITON_BIN device adb-shell screencap -p /sdcard/Download/shot.png` | ok - retrieve with `file pull` (or use `device screen` directly) |
+| Read system setting | `$KOBITON_BIN device adb-shell settings get system <key>` | rejected - only the `secure enabled_accessibility_services` key is readable/writable |
+| Write system setting | `$KOBITON_BIN device adb-shell settings put system <key> <value>` | rejected - same single-key rule |
+| Read/write enabled accessibility services | `$KOBITON_BIN device adb-shell settings get secure enabled_accessibility_services` / `... put secure enabled_accessibility_services <value>` | ok - the one permitted settings key (`<value>` is colon-separated components, or `null` to clear) |
+| Read file content | `$KOBITON_BIN device adb-shell cat <path>` | path allowlist applies (allowed dirs + `/proc/version`) |
+| List directory | `$KOBITON_BIN device adb-shell ls -la <path>` | path allowlist applies - outside it, use `$KOBITON_BIN file list <path>` |
+| Current IME | `$KOBITON_BIN device adb-shell "dumpsys input_method \| grep mCurId"` | quoted pipe rejected - run bare `dumpsys input_method`, filter locally |
+
+**Big-output commands.** `dumpsys`, `logcat`, `pm list -f`, and full process dumps can blow past the 25k-token MCP limit. For these, redirect to an artifact file first, then read/grep only what you need (the redirect is your *local* shell's, so this exact pattern also works on restricted sessions - it is the same local-composition idiom from the quoting rules):
 
     $KOBITON_BIN device adb-shell logcat -d -t 1000 \
       > .kobiton/sessions/<session-id>/logcat-$(date +%s).txt
@@ -309,7 +349,7 @@ These commands require an active session. Run `$KOBITON_BIN <command> --help` to
 | Domain | Command | What it does |
 |--------|---------|-------------|
 | Device | `$KOBITON_BIN device screen` | Capture device screen as jpg |
-| Device | `$KOBITON_BIN device forward <local> <remote>` | Forward local port to device |
+| Device | `$KOBITON_BIN device forward <local> <remote>` | Forward local port to device. Runs in the foreground until interrupted and holds the local port for the lifetime of the forward - launch with `run_in_background: true` and kill explicitly, like the long-running adb-shell commands above |
 | Device | `$KOBITON_BIN device ps` | List processes on device |
 | File | `$KOBITON_BIN file list <path>` | List files on device |
 | File | `$KOBITON_BIN file push <local> <remote>` | Push file to device |

--- a/skills/run-interactive-session/references/response-shapes.md
+++ b/skills/run-interactive-session/references/response-shapes.md
@@ -27,9 +27,10 @@ Most WebDriver endpoints return a JSON envelope `{"value": <result>}`. A few com
 
 | Command | Response on stdout | How to read |
 |---|---|---|
-| `device adb-shell <cmd>` | Raw stdout from the on-device shell. Shape depends on `<cmd>` - KV pairs (`dumpsys battery`), single line (`getprop`), multi-line table (`pm list`, `ps`), or free text (`logcat`) | (a) For single-value extractions, `grep` or `awk` the line. (b) For multi-line output, save to artifact then parse. (c) **Gotcha:** exit code 0 does NOT mean the inner command succeeded - adb returns 0 as long as it could deliver the command; check stderr or look for error strings in stdout. |
+| `device adb-shell <cmd>` | Raw stdout from the on-device shell. Shape depends on `<cmd>` - KV pairs (`dumpsys battery`), single line (`getprop`), multi-line table (`pm list`, `ps`), or free text (`logcat`) | (a) For single-value extractions, `grep` or `awk` the line. (b) For multi-line output, save to artifact then parse. (c) **Gotcha:** exit code 0 does NOT mean the inner command succeeded - adb returns 0 as long as it could deliver the command; check stderr or look for error strings in stdout. (d) On restricted sessions (public cloud / trial devices) a **whitelist rejection also lands on stdout at exit 0** - string-match the first line against `Input contains a forbidden character:`, `Command is not on the whitelist:`, `Argument is not permitted for`, and `Only get/put of secure enabled_accessibility_services is permitted` before trusting empty or short output (see the SKILL's Restricted sessions block). |
 | `device screen` | JPEG image bytes - check `--help` for output flag (e.g., `--out`) | Redirect or use the documented output flag |
-| `device forward`, `device ps`, `file list` | Plain text on stdout | Read directly |
+| `device forward` | `Listening on <addr>.` then blocks - the command runs in the foreground for the lifetime of the forward and holds the local port | A non-returning invocation is normal, not a hang; launch with `run_in_background: true` and kill explicitly to release the port |
+| `device ps`, `file list` | Plain text on stdout | Read directly |
 | `file push`, `file pull` | Text confirmation; non-zero exit on failure | Surface failures by exit code |
 | `app run <app-id>` | Text confirmation; the app launches on the device | Continue interacting after launch |
 | `test run` | Streaming test-runner output | Run with `run_in_background: true`; parse the final summary block |


### PR DESCRIPTION
## Problem

The `run-interactive-session` adb-shell guidance historically taught quoting the remote command so metacharacters run on-device:

```
kobiton device adb-shell "dumpsys window | grep mCurrentFocus"
```

On public cloud and trial devices the shell is restricted, and that form is rejected outright — the pipe **and the quotes themselves** are forbidden characters — with the rejection arriving on stdout at exit 0. An agent following the docs composes commands that can never work there, and can't tell the refusal from a result. 1.10.0 added basic restricted-shell notes (bare-command + local-filter); this PR replaces them with the complete policy.

Fixes #108. Covers the documentation half of #107 and the command-table half of #109 (the CLI `--help` and website halves are tracked separately).

## Changes

- **New "Restricted sessions" policy block** in the adb-shell section: the forbidden-character set, command whitelist by category, file-path allowlist, the single permitted `settings` key, the four rejection message shapes with the exit-0 gotcha (incl. the settings-specific message — verified live on restricted test-env devices 2026-08-13 by the KOB-54475 contract spec), and a pointer to `kobiton device adb-shell --help` as the always-current authority.
- **Quoting rules split by scope**: the quoted form is scoped to unrestricted (dedicated) devices; restricted sessions get the working idiom — run the bare whitelisted command, redirect locally into the session artifact dir, filter locally.
- **Command table gains a Restricted column** covering every row: local-compose alternatives for the quoted-pipe rows, `settings system` rows marked rejected with the allowed `secure enabled_accessibility_services` row added, path-allowlist notes on `cat`/`ls`, the `input text` single-token limit, `wm size` → `wd get window/rect`, a new `screencap` row, and de-quoted `logcat`. 1.10.0's rows (Open-a-URL Android/iOS, iOS `device log` pointer) are preserved and annotated.
- **`device forward`** documented as a foreground command that holds the local port until killed (here and in `references/response-shapes.md`).
- **`references/response-shapes.md`**: the three rejection strings added to the existing exit-code gotcha so agents string-match refusals before trusting empty output.
- **`AGENTS.md`** carries the same facts for non-Claude hosts; **`.codex/`** mirror regenerated via `pnpm run build:codex`.

Version 1.10.1 (docs-only release). `pnpm run validate` and all 193 tests green.

## Rebase note

Rebased onto main after #114 (pinned CLI download). Two parts of the original branch were dropped as superseded:
- the bundled-binary refresh — the CLI is no longer committed to the repo; the pinned build the installer downloads is built from the same source and already carries the file-transfer status fix this branch originally bundled;
- the 1.9.1 version bump — renumbered to 1.10.1 on top of 1.10.0.

## Release coordination

~~Hold until the deviceConnect sanitizer expansion reaches prod.~~ **Cleared 2026-08-13:** all four expanded whitelist entries (`cat /proc/version`, `screencap`, `input`, the `settings secure enabled_accessibility_services` key) verified working on a prod restricted public device, with the quoted-pipe rejection and the settings-specific rejection message matching these docs verbatim. Prod deviceConnect carries the expanded policy; the docs are releasable as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)