### PR TITLE
fix: sync startNativeSession schema with its source branch

### DIFF
--- a/tools/sessions.yaml
+++ b/tools/sessions.yaml
@@ -232,10 +232,11 @@ tools:
           enum:
             - KOBITON
             - ORGANIZATION
-            - CLOUD
+            - ANY
           description: >-
-            Which device pool to book from. KOBITON = Kobiton cloud devices,
-            ORGANIZATION = your organization's own devices.
+            Which device pool to book from. KOBITON = Kobiton public cloud
+            devices, ORGANIZATION = your organization's own private devices,
+            ANY = search both pools. Defaults to ANY when omitted.
         groupId:
           type: integer
           description: Team ID to run the session under
@@ -243,18 +244,25 @@ tools:
           type: string
           description: >-
             App under test, as a kobiton-store:<appId> identifier returned by
-            uploadAppToStore
+            uploadAppToStore. Required for XCUITEST and UIAUTOMATOR — the
+            server rejects the call when omitted.
         testRunner:
           type: string
           description: >-
             Test runner bundle (XCUITest test-runner .ipa, UIAutomator test
-            .apk, or GameDriver runner), as a kobiton-store:<appId> identifier
+            .apk, or GameDriver runner), as a kobiton-store:<appId> identifier.
+            Required for XCUITEST and UIAUTOMATOR — the server rejects the
+            call when omitted.
         noReset:
           type: boolean
-          description: Keep app data between runs (do not reset the app)
+          description: >-
+            Keep app data between runs (do not reset the app). Mutually
+            exclusive with fullReset — set at most one of the two.
         fullReset:
           type: boolean
-          description: Uninstall and reinstall the app before the run
+          description: >-
+            Uninstall and reinstall the app before the run. Mutually exclusive
+            with noReset — set at most one of the two.
         sessionTimeout:
           type: integer
           description: Maximum session duration in minutes (default 60)
@@ -274,7 +282,9 @@ tools:
             executions.
         runCommand:
           type: string
-          description: GameDriver only — command line used to launch the runner
+          description: >-
+            GameDriver only — command line used to launch the runner. Ignored
+            for XCUITEST and UIAUTOMATOR.
         args:
           type: array
           description: Extra arguments passed to the test runner


### PR DESCRIPTION
`aya-develop` carries a **stale copy** of `startNativeSession`, and one of the differences publishes an enum value the server does not accept.

## How it happened

KOB-54335 copied `tools/sessions.yaml` from KOB-54362 on Aug 18, so that building the tool catalog from an `aya-develop`-based branch would not silently drop `startNativeSession` — a handler with no schema entry disappears from clients' tool lists with no error. That PR then merged. KOB-54362 corrected its own schema on Aug 19 (`0ee4998`), so `aya-develop` now holds a pre-correction version of a tool it does not own.

## What is wrong in the current file

| Field | On `aya-develop` (stale) | Correct |
|---|---|---|
| `deviceGroup` enum | `KOBITON, ORGANIZATION, `**`CLOUD`** | `KOBITON, ORGANIZATION, `**`ANY`** |
| `app` / `testRunner` | described as optional | **required** for `XCUITEST` and `UIAUTOMATOR` — the server rejects the call when omitted |
| `noReset` | no constraint documented | **mutually exclusive** with `fullReset` |

The enum is the one that actively misleads: `CLOUD` is not a value the server accepts, so a model that picks it from the published schema gets a rejected call with nothing in the schema to explain why. `ANY` (search both pools, and the default when omitted) is the real third option.

The other two turn silent server-side rejections into documented requirements, which is the difference between a model retrying blindly and getting it right first time.

## Approach

Takes KOB-54362's file **wholesale** rather than hand-merging the three changes, so the two branches stay byte-identical and this cannot drift again. No other file is touched — `tools/aya.yaml` and everything else are untouched by this PR.

## Verification

`pnpm run validate` passes (`tools/sessions.yaml is valid (6 tools)`, `tools/aya.yaml is valid (2 tools)`, `.codex/` mirror in sync) and `pnpm test` passes (189 tests).

## Note on the published catalog

The catalog currently published to S3 was built from the stale file, so it carries `CLOUD` as well. Republishing after this merges will correct it — worth doing alongside whoever next publishes, rather than as a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)